### PR TITLE
Allow string array for minecraft:spell_effects remove_effect.

### DIFF
--- a/source/behavior/entities/1.8.0/components/minecraft.spell_effects.json
+++ b/source/behavior/entities/1.8.0/components/minecraft.spell_effects.json
@@ -16,8 +16,15 @@
           { "type": "object", "properties": { "effect": { "type": "string" }, "duration": { "type": "integer" }, "display_on_screen_animation": { "type": "boolean" } } }
         ]
       },
-      "title": "TODO Title"
+      "title": "Add Effects"
     },
-    "remove_effects": { "type": "string", "description": "List of identifiers of effects to be removed from this entity after adding this component", "title": "TODO Title" }
+    "remove_effects": {
+      "type": ["array", "string"],
+      "description": "List of identifiers of effects to be removed from this entity after adding this component", 
+      "items": {
+        "type": ["string"]
+      },
+      "title": "Remove Effects"
+    }
   }
 }


### PR DESCRIPTION
Although most documentation suggests this is only a string, the vanilla behaviour pack `items/honey_bottle.json` demonstrates that arrays of strings are also valid. I've tested this, and can confirm multiple effects are correctly removed when multiple strings are provided in the array.