### PR TITLE
Modify timer schema

### DIFF
--- a/source/behavior/entities/format/components/timer.json
+++ b/source/behavior/entities/format/components/timer.json
@@ -69,7 +69,10 @@
     {
       "time": 1,
       "looping": true,
-      "time_down_event": "self:reset"
+      "time_down_event": {
+        "event": "example:foo",
+        "target": "self"
+      }
     }
   ]
 }

--- a/source/behavior/entities/format/components/timer.json
+++ b/source/behavior/entities/format/components/timer.json
@@ -58,7 +58,8 @@
           },
           "value": {
             "type": "integer",
-            "description": "UNDOCUMENTED: value",
+            "description": "The value in seconds that would be used if this section was picked",
+            "$comment": "UNDOCUMENTED",
             "title": "Value"
           }
         }


### PR DESCRIPTION
- Update the example to use the correct event schema. Previously it was using a string and not the event schema.
- Wrote documentation for the `value` field in `random_time_choices` 