### PR TITLE
Set min/max for effect amplifier & document it

### DIFF
--- a/source/behavior/entities/format/components/spell_effects.json
+++ b/source/behavior/entities/format/components/spell_effects.json
@@ -19,9 +19,10 @@
               "amplifier": {
                 "type": "integer",
                 "title": "Amplifier",
-                "description": "The level of the effect, same as used in the /effect command (0 for level I, 1 for level II, etc). Defaults to 0.",
+                "description": "The level of the effect, same as used in the /effect command (0 for level I, 1 for level II, etc). Defaults to 0. Supports negative values, which reverse the effect.",
                 "default": 0,
-                "minimum": 0
+                "minimum": -255,
+                "maximum": 255
               },
               "ambient": {
                 "title": "Ambient",


### PR DESCRIPTION
Turns out, this field actually supports negative values! This also adds a short excerpt at the end of the description, it can be removed if deemed unnecessary.