### PR TITLE
Add various enums and constraints and direction property in particle

### DIFF
--- a/source/behavior/entities/format/behaviors/avoid_block.json
+++ b/source/behavior/entities/format/behaviors/avoid_block.json
@@ -31,7 +31,7 @@
       "type": "string",
       "title": "Target Selection Method",
       "description": "Block search method.",
-      "enum": ["nearest"]
+      "enum": ["random", "nearest"]
     },
     "target_blocks": {
       "type": "array",

--- a/source/behavior/entities/format/behaviors/lay_egg.json
+++ b/source/behavior/entities/format/behaviors/lay_egg.json
@@ -65,7 +65,8 @@
     "target_materials_above_block": {
       "title": "Target Materials Above Block",
       "type": "array",
-      "default": ["air"],
+      "default": ["Air"],
+      "enum": ["Air", "Any", "Lava", "Water"],
       "description": "[EXPERIMENTAL] Types of materials that can exist above the target block. Valid types are Air, Water, and Lava."
     },
     "use_default_animation": {

--- a/source/behavior/entities/format/behaviors/move_to_liquid.json
+++ b/source/behavior/entities/format/behaviors/move_to_liquid.json
@@ -35,6 +35,7 @@
       "title": "Material Type",
       "description": "The material type of the liquid block to find. Valid values are 'Any', 'Water', and 'Lava'.",
       "default": "Any",
+      "enum": ["Air", "Any", "Lava", "Water"],
       "type": "string"
     }
   },

--- a/source/behavior/entities/format/behaviors/move_to_poi.json
+++ b/source/behavior/entities/format/behaviors/move_to_poi.json
@@ -15,7 +15,8 @@
     "poi_type": {
       "type": "string",
       "description": "Tells the goal what POI type it should be looking for.",
-      "title": "Point Of Interest Type"
+      "title": "Point Of Interest Type",
+      "enum": ["bed", "jobsite", "meeting_area"]
     }
   },
   "examples": [

--- a/source/behavior/entities/format/behaviors/summon_entity.json
+++ b/source/behavior/entities/format/behaviors/summon_entity.json
@@ -111,6 +111,7 @@
                   "type": "string",
                   "default": "line",
                   "description": "The base shape of this step. Valid values are circle and line",
+                  "enum": ["line", "circle"],
                   "title": "Shape"
                 },
                 "size": {

--- a/source/behavior/entities/format/behaviors/work.json
+++ b/source/behavior/entities/format/behaviors/work.json
@@ -12,7 +12,8 @@
       "title": "Active Time",
       "type": "integer",
       "default": 0,
-      "description": "The amount of ticks the NPC will stay in their the work location."
+      "description": "The amount of ticks the NPC will stay in their the work location.",
+      "exclusiveMinimum": 0
     },
     "can_work_in_rain": {
       "title": "Can Work In Rain",

--- a/source/resource/particles/components/particle_appearance_billboard.json
+++ b/source/resource/particles/components/particle_appearance_billboard.json
@@ -18,12 +18,39 @@
       "enum": ["lookat_xyz", "lookat_y", "rotate_xyz", "rotate_y", "direction_x", "direction_y", "direction_z"],
       "title": "Facing Camera Mode"
     },
+    "direction": {
+      "type": "object",
+      "description": "UNDOCUMENTED",
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["custom", "derive_from_velocity"],
+          "description": "Specified how to calculate the billboard direction of a particle."
+        },
+        "custom_direction": {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 3,
+          "items": { "$ref": "../../../molang/number.json", "description": "UNDOCUMENTED." },
+          "description": "The facing direction of emitted particles."
+        },
+        "min_speed_threshold": {
+          "type": "number",
+          "description": "The direction is set if the speed of the particle is above the threshold.",
+          "default": 0.01
+        }
+      }
+    },
     "uv": {
       "additionalProperties": false,
       "type": "object",
       "properties": {
         "texture_width": { "type": "integer", "description": "UNDOCUMENTED: texture width.", "title": "Texture Width" },
-        "texture_height": { "type": "integer", "description": "UNDOCUMENTED: texture height.", "title": "Texture Height" },
+        "texture_height": {
+          "type": "integer",
+          "description": "UNDOCUMENTED: texture height.",
+          "title": "Texture Height"
+        },
         "flipbook": {
           "additionalProperties": false,
           "type": "object",
@@ -33,7 +60,11 @@
               "type": "array",
               "minItems": 2,
               "maxItems": 2,
-              "items": { "$ref": "../../../molang/number.json", "description": "UNDOCUMENTED: base UV.", "title": "Base U V" },
+              "items": {
+                "$ref": "../../../molang/number.json",
+                "description": "UNDOCUMENTED: base UV.",
+                "title": "Base U V"
+              },
               "description": "UNDOCUMENTED: base UV.",
               "title": "Base U V"
             },
@@ -41,7 +72,11 @@
               "type": "array",
               "minItems": 2,
               "maxItems": 2,
-              "items": { "$ref": "../../../molang/number.json", "description": "UNDOCUMENTED: size UV.", "title": "Size U V" },
+              "items": {
+                "$ref": "../../../molang/number.json",
+                "description": "UNDOCUMENTED: size UV.",
+                "title": "Size U V"
+              },
               "description": "UNDOCUMENTED: size UV.",
               "title": "Size U V"
             },
@@ -49,7 +84,11 @@
               "type": "array",
               "minItems": 2,
               "maxItems": 2,
-              "items": { "$ref": "../../../molang/number.json", "description": "UNDOCUMENTED: step UV.", "title": "Step U V" },
+              "items": {
+                "$ref": "../../../molang/number.json",
+                "description": "UNDOCUMENTED: step UV.",
+                "title": "Step U V"
+              },
               "description": "UNDOCUMENTED: step UV.",
               "title": "Step U V"
             },
@@ -58,8 +97,16 @@
               "description": "UNDOCUMENTED: frames per second.",
               "title": "Frames Per Second"
             },
-            "max_frame": { "$ref": "../../../molang/number.json", "description": "UNDOCUMENTED: Maximum frame.", "title": "Maximum Frame" },
-            "stretch_to_lifetime": { "type": "boolean", "description": "UNDOCUMENTED: stretch to lifetime.", "title": "Stretch To Lifetime" },
+            "max_frame": {
+              "$ref": "../../../molang/number.json",
+              "description": "UNDOCUMENTED: Maximum frame.",
+              "title": "Maximum Frame"
+            },
+            "stretch_to_lifetime": {
+              "type": "boolean",
+              "description": "UNDOCUMENTED: stretch to lifetime.",
+              "title": "Stretch To Lifetime"
+            },
             "loop": { "type": "boolean", "description": "UNDOCUMENTED: loop.", "title": "Loop" }
           },
           "description": "UNDOCUMENTED: flipbook.",
@@ -77,7 +124,11 @@
           "type": "array",
           "minItems": 2,
           "maxItems": 2,
-          "items": { "$ref": "../../../molang/number.json", "description": "UNDOCUMENTED: uv size.", "title": "Uv Size" },
+          "items": {
+            "$ref": "../../../molang/number.json",
+            "description": "UNDOCUMENTED: uv size.",
+            "title": "Uv Size"
+          },
           "description": "UNDOCUMENTED: uv size.",
           "title": "Uv Size"
         }


### PR DESCRIPTION
Added constraints:
 - `active_time` in minecraft:behavior.work component must be greater than 0

Added enums:
 - `target_selection_method` in minecraft:behavior.avoid_block was missing `random`
 - `target_materials_above_block` in minecraft:behavior.lay_egg
 - `material_type` in minecraft:behavior.move_to_liquid
 - `poi_type` in minecraft:behavior.move_to_poi
 - `shape` in minecraft:behavior.summon_entity

Also added `direction` field to `minecraft:particle_appearance_billboard` particle component.