### PR TITLE
Fixed "format_version" in blocks.json + changes.

### DIFF
--- a/source/resource/blocks.json
+++ b/source/resource/blocks.json
@@ -115,7 +115,37 @@
           "$ref": "../general/format_version.json"
         },
         {
-          "$ref": "#/definitions/B"
+      "title": "Format Version",
+      "description": "A version that tells Minecraft what type of data format can be expected when reading this file.",
+      "type": "array",
+      "default": [
+        1,
+        1,
+        0
+      ],
+      "examples": [
+        [
+          1,
+          1,
+          0
+        ]
+      ],
+      "items": {
+        "type": "integer"
+      },
+      "minItems": 3,
+      "maxItems": 3,
+      "uniqueItems": false,
+      "defaultSnippets": [
+        {
+          "label": "New Format version",
+          "body": [
+            1,
+            1,
+            0
+          ]
+        }
+      ]
         }
       ]
     }

--- a/source/resource/blocks.json
+++ b/source/resource/blocks.json
@@ -7,148 +7,26 @@
   "definitions": {
     "texture": {
       "oneOf": [
-        {
-          "type": "string"
-        },
+        { "type": "string" },
         {
           "additionalProperties": false,
           "type": "object",
           "properties": {
-            "down": {
-              "type": "string",
-              "pattern": "^[\\w_\\-]+$"
-            },
-            "up": {
-              "type": "string",
-              "pattern": "^[\\w_\\-]+$"
-            },
-            "side": {
-              "type": "string",
-              "pattern": "^[\\w_\\-]+$"
-            },
-            "south": {
-              "type": "string",
-              "pattern": "^[\\w_\\-]+$"
-            },
-            "north": {
-              "type": "string",
-              "pattern": "^[\\w_\\-]+$"
-            },
-            "west": {
-              "type": "string",
-              "pattern": "^[\\w_\\-]+$"
-            },
-            "east": {
-              "type": "string",
-              "pattern": "^[\\w_\\-]+$"
-            }
+            "down": { "type": "string", "pattern": "^[\\w_\\-]+$" },
+            "up": { "type": "string", "pattern": "^[\\w_\\-]+$" },
+            "side": { "type": "string", "pattern": "^[\\w_\\-]+$" },
+            "south": { "type": "string", "pattern": "^[\\w_\\-]+$" },
+            "north": { "type": "string", "pattern": "^[\\w_\\-]+$" },
+            "west": { "type": "string", "pattern": "^[\\w_\\-]+$" },
+            "east": { "type": "string", "pattern": "^[\\w_\\-]+$" }
           }
         }
       ]
-    },
-    "A": {
-      "title": "Format Version",
-      "description": "A version that tells minecraft what type of data format can be expected when reading this file.",
-      "pattern": "^([1-9]+)\\.([0-9]+)\\.([0-9]+)$",
-      "type": "string",
-      "default": "1.19.40",
-      "examples": [
-        "1.19.40",
-        "1.18.0",
-        "1.17.0",
-        "1.16.0",
-        "1.15.0",
-        "1.14.0",
-        "1.13.0",
-        "1.12.0",
-        "1.10.0",
-        "1.8.0"
-      ],
-      "defaultSnippets": [
-        {
-          "label": "New Format version",
-          "body": "1.${1|8,10,12,17,18,19|}.${3|2|0|}"
-        }
-      ]
-    },
-    "B": {
-      "title": "Format Version",
-      "description": "A version that tells minecraft what type of data format can be expected when reading this file.",
-      "type": "array",
-      "default": [
-        1,
-        1,
-        0
-      ],
-      "examples": [
-        [
-          1,
-          1,
-          0
-        ]
-      ],
-      "items": {
-        "type": "integer"
-      },
-      "minItems": 3,
-      "maxItems": 3,
-      "uniqueItems": false,
-      "defaultSnippets": [
-        {
-          "label": "New Format version",
-          "body": [
-            1,
-            1,
-            0
-          ]
-        }
-      ]
     }
   },
-  "propertyNames": {
-    "pattern": "^[\\w_\\-:\\.]+$"
-  },
+  "propertyNames": { "pattern": "^[\\w_\\-:\\.]+$" },
   "properties": {
-    "format_version": {
-      "oneOf": [
-        {
-          "$ref": "../general/format_version.json"
-        },
-        {
-      "title": "Format Version",
-      "description": "A version that tells Minecraft what type of data format can be expected when reading this file.",
-      "type": "array",
-      "default": [
-        1,
-        1,
-        0
-      ],
-      "examples": [
-        [
-          1,
-          1,
-          0
-        ]
-      ],
-      "items": {
-        "type": "integer"
-      },
-      "minItems": 3,
-      "maxItems": 3,
-      "uniqueItems": false,
-      "defaultSnippets": [
-        {
-          "label": "New Format version",
-          "body": [
-            1,
-            1,
-            0
-          ]
-        }
-      ]
-        }
-      ]
-    }
+    "format_version": { "$ref": "../general/format_version.json" }
   },
   "additionalProperties": {
     "additionalProperties": false,
@@ -170,48 +48,24 @@
         "title": "Isotropic",
         "description": "Marks if this block is isotropic or not, or which side are.",
         "oneOf": [
-          {
-            "type": "boolean"
-          },
+          { "type": "boolean" },
           {
             "additionalProperties": false,
             "type": "object",
             "properties": {
-              "down": {
-                "type": "boolean"
-              },
-              "up": {
-                "type": "boolean"
-              },
-              "side": {
-                "type": "boolean"
-              },
-              "south": {
-                "type": "boolean"
-              },
-              "north": {
-                "type": "boolean"
-              },
-              "west": {
-                "type": "boolean"
-              },
-              "east": {
-                "type": "boolean"
-              }
+              "down": { "type": "boolean" },
+              "up": { "type": "boolean" },
+              "side": { "type": "boolean" },
+              "south": { "type": "boolean" },
+              "north": { "type": "boolean" },
+              "west": { "type": "boolean" },
+              "east": { "type": "boolean" }
             }
           }
         ]
       },
-      "sound": {
-        "type": "string",
-        "title": "Sound",
-        "description": "The sound definition of this block."
-      },
-      "textures": {
-        "$ref": "#/definitions/texture",
-        "title": "Sound",
-        "description": "Textures."
-      }
+      "sound": { "type": "string", "title": "Sound", "description": "The sound definition of this block." },
+      "textures": { "$ref": "#/definitions/texture", "title": "Sound", "description": "Textures." }
     }
   }
 }

--- a/source/resource/blocks.json
+++ b/source/resource/blocks.json
@@ -7,26 +7,118 @@
   "definitions": {
     "texture": {
       "oneOf": [
-        { "type": "string" },
+        {
+          "type": "string"
+        },
         {
           "additionalProperties": false,
           "type": "object",
           "properties": {
-            "down": { "type": "string", "pattern": "^[\\w_\\-]+$" },
-            "up": { "type": "string", "pattern": "^[\\w_\\-]+$" },
-            "side": { "type": "string", "pattern": "^[\\w_\\-]+$" },
-            "south": { "type": "string", "pattern": "^[\\w_\\-]+$" },
-            "north": { "type": "string", "pattern": "^[\\w_\\-]+$" },
-            "west": { "type": "string", "pattern": "^[\\w_\\-]+$" },
-            "east": { "type": "string", "pattern": "^[\\w_\\-]+$" }
+            "down": {
+              "type": "string",
+              "pattern": "^[\\w_\\-]+$"
+            },
+            "up": {
+              "type": "string",
+              "pattern": "^[\\w_\\-]+$"
+            },
+            "side": {
+              "type": "string",
+              "pattern": "^[\\w_\\-]+$"
+            },
+            "south": {
+              "type": "string",
+              "pattern": "^[\\w_\\-]+$"
+            },
+            "north": {
+              "type": "string",
+              "pattern": "^[\\w_\\-]+$"
+            },
+            "west": {
+              "type": "string",
+              "pattern": "^[\\w_\\-]+$"
+            },
+            "east": {
+              "type": "string",
+              "pattern": "^[\\w_\\-]+$"
+            }
           }
+        }
+      ]
+    },
+    "A": {
+      "title": "Format Version",
+      "description": "A version that tells minecraft what type of data format can be expected when reading this file.",
+      "pattern": "^([1-9]+)\\.([0-9]+)\\.([0-9]+)$",
+      "type": "string",
+      "default": "1.19.40",
+      "examples": [
+        "1.19.40",
+        "1.18.0",
+        "1.17.0",
+        "1.16.0",
+        "1.15.0",
+        "1.14.0",
+        "1.13.0",
+        "1.12.0",
+        "1.10.0",
+        "1.8.0"
+      ],
+      "defaultSnippets": [
+        {
+          "label": "New Format version",
+          "body": "1.${1|8,10,12,17,18,19|}.${3|2|0|}"
+        }
+      ]
+    },
+    "B": {
+      "title": "Format Version",
+      "description": "A version that tells minecraft what type of data format can be expected when reading this file.",
+      "type": "array",
+      "default": [
+        1,
+        1,
+        0
+      ],
+      "examples": [
+        [
+          1,
+          1,
+          0
+        ]
+      ],
+      "items": {
+        "type": "integer"
+      },
+      "minItems": 3,
+      "maxItems": 3,
+      "uniqueItems": false,
+      "defaultSnippets": [
+        {
+          "label": "New Format version",
+          "body": [
+            1,
+            1,
+            0
+          ]
         }
       ]
     }
   },
-  "propertyNames": { "pattern": "^[\\w_\\-:\\.]+$" },
+  "propertyNames": {
+    "pattern": "^[\\w_\\-:\\.]+$"
+  },
   "properties": {
-    "format_version": { "$ref": "../general/format_version.json" }
+    "format_version": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/A"
+        },
+        {
+          "$ref": "#/definitions/B"
+        }
+      ]
+    }
   },
   "additionalProperties": {
     "additionalProperties": false,
@@ -37,37 +129,59 @@
       "brightness_gamma": {
         "type": "number",
         "title": "Brightness Gamma",
-        "description": "UNDOCUMENTED.",
-        "$comment": "UNDOCUMENTED"
+        "description": "Specifies the gamma brightness level to apply to the block texture."
       },
       "carried_textures": {
         "$ref": "#/definitions/texture",
         "title": "Carried Textures",
-        "description": "UNDOCUMENTED.",
-        "$comment": "UNDOCUMENTED"
+        "description": "Carried Textures."
       },
       "isotropic": {
         "title": "Isotropic",
         "description": "Marks if this block is isotropic or not, or which side are.",
         "oneOf": [
-          { "type": "boolean" },
+          {
+            "type": "boolean"
+          },
           {
             "additionalProperties": false,
             "type": "object",
             "properties": {
-              "down": { "type": "boolean" },
-              "up": { "type": "boolean" },
-              "side": { "type": "boolean" },
-              "south": { "type": "boolean" },
-              "north": { "type": "boolean" },
-              "west": { "type": "boolean" },
-              "east": { "type": "boolean" }
+              "down": {
+                "type": "boolean"
+              },
+              "up": {
+                "type": "boolean"
+              },
+              "side": {
+                "type": "boolean"
+              },
+              "south": {
+                "type": "boolean"
+              },
+              "north": {
+                "type": "boolean"
+              },
+              "west": {
+                "type": "boolean"
+              },
+              "east": {
+                "type": "boolean"
+              }
             }
           }
         ]
       },
-      "sound": { "type": "string", "title": "Sound", "description": "The sound definition of this block." },
-      "textures": { "$ref": "#/definitions/texture", "title": "Sound", "description": "Textures." }
+      "sound": {
+        "type": "string",
+        "title": "Sound",
+        "description": "The sound definition of this block."
+      },
+      "textures": {
+        "$ref": "#/definitions/texture",
+        "title": "Sound",
+        "description": "Textures."
+      }
     }
   }
 }

--- a/source/resource/blocks.json
+++ b/source/resource/blocks.json
@@ -112,7 +112,7 @@
     "format_version": {
       "oneOf": [
         {
-          "$ref": "#/definitions/A"
+          "$ref": "../general/format_version.json"
         },
         {
           "$ref": "#/definitions/B"


### PR DESCRIPTION
Fixed "format_version" in blocks.json + changes.

Attempted to resolve the bug https://github.com/Blockception/Minecraft-bedrock-json-schemas/issues/156 by adding support for array type.

Also added some documentation to a few of the block.json keys for Gamma, and Carried Textures.