### PR TITLE
Added missing "first_spawn_chance" information.

### DIFF
--- a/source/behavior/entities/format/components/projectile.json
+++ b/source/behavior/entities/format/components/projectile.json
@@ -525,6 +525,12 @@
               "default": 0,
               "description": "The chance that a spawn occurs when a projectile hits the entity."
             },
+            "first_spawn_chance": {
+              "title": "First Spawn Chance",
+              "type": "number",
+              "default": 8,
+              "description": "The chance that a first spawn occurs when a projectile hits the entity."
+            },
             "second_spawn_chance": {
               "title": "Second Spawn Chance",
               "type": "number",


### PR DESCRIPTION
Added missing "first_spawn_chance" information to the projectile behavior inside of "minecraft:projectile" key inside of "on_hit" key inside of "spawn_chance" key.

I plan on doing a few more small pull requests here and there when I'm able.