### PR TITLE
Updated knockback_resistance component's max value

### DIFF
--- a/source/behavior/entities/format/components/knockback_resistance.json
+++ b/source/behavior/entities/format/components/knockback_resistance.json
@@ -13,12 +13,15 @@
       "default": 1.0,
       "description": "Percentage of knockback to reduce with 1.0 being 100% reduction.",
       "$comment": "UNDOCUMENTED",
-      "maximum": 1
+      "maximum": 100
     }
   },
   "examples": [
     {
       "value": 1.0
+    },
+    {
+      "value": 100
     }
   ]
 }


### PR DESCRIPTION
The minecraft:ender_dragon uses a value that is 100x higher than 1.0, I've increased the max cap on this component to at least that amount.

Found in the vanilla behavior pack.
ender_dragon.json
```
      "minecraft:knockback_resistance": {
        "value": 100,
        "max": 100
      }
```

Also added another example:
    {
      "value": 100
    }