### PR TITLE
minecraft:physics - added "push_towards_closest_space"

### DIFF
--- a/source/behavior/entities/format/components/physics.json
+++ b/source/behavior/entities/format/components/physics.json
@@ -3,13 +3,13 @@
   "additionalProperties": false,
   "type": "object",
   "title": "Physics",
-  "description": "Defines physics properties of an actor, including if it is affected by gravity or if it collides with objects.",
+  "description": "Defines the physical properties of an actor, including whether it is affected by gravity, whether it collides with objects, or whether it is pushed to the closest space.",
   "required": [],
   "properties": {
     "has_collision": {
       "type": "boolean",
       "default": true,
-      "description": "Whether or not the object collides with things.",
+      "description": "Whether or not the entity collides with things.",
       "title": "Has Collision"
     },
     "has_gravity": {
@@ -17,7 +17,13 @@
       "default": true,
       "description": "Whether or not the entity is affected by gravity.",
       "title": "Has Gravity"
+    },
+    "push_towards_closest_space": {
+      "type": "boolean",
+      "default": true,
+      "description": "Whether or not the entity is pushed to the closest space.",
+      "title": "Pushed Towards Closest Space"
     }
   },
-  "examples": [{}, { "has_collision": true, "has_gravity": true }]
+  "examples": [{}, { "has_collision": true, "has_gravity": true }, { "push_towards_closest_space": true}]
 }


### PR DESCRIPTION
- Updated physics.json with new variable "push_towards_closest_space" and updated documentation to be consistent, added another example.

- The "push_towards_closest_space" is found on entities/player.json in the behavior pack in the version 1.19.50;