### PR TITLE
Update anger_level.json

### DIFF
--- a/source/behavior/entities/format/components/anger_level.json
+++ b/source/behavior/entities/format/components/anger_level.json
@@ -28,9 +28,15 @@
     },
     "default_annoyingness": {
       "title": "Default Annoyingness",
-      "type": "string",
-      "default": "0",
+      "type": "number",
+      "default": 0,
       "description": "The default amount of annoyingness for any given nuisance. Specifies how much to raise anger level on each provocation"
+    },
+    "default_projectile_annoyingness": {
+      "title": "Default Projectile Annoyingness",
+      "type": "number",
+      "default": 0,
+      "description": "The default amount of annoyingness for projectile nuisance. Specifies how much to raise anger level on each provocation"
     },
     "max_anger": {
       "title": "Maximum Anger",


### PR DESCRIPTION
Updated the anger_level.json

"default_annoyingness" can be a float, int, or string, and the warden is currently using an integer so I've made a change so this will use a "number" instead of a "string" for its value type as it's more flexible.

![image](https://github.com/Blockception/Minecraft-bedrock-json-schemas/assets/17806994/f33082dd-b8f1-41ad-9827-48391a56a131)

Also added a missing warden argument called "default_projectile_annoyingness": 35

Added some documentation for the above.
![image](https://github.com/Blockception/Minecraft-bedrock-json-schemas/assets/17806994/dae32e32-2039-4d1d-baee-f28c84fe59e0)

