### PR TITLE
Add 9Slice schema

### DIFF
--- a/source/resource/textures/nine_slice.json
+++ b/source/resource/textures/nine_slice.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "blockception.minecraft.resource.texture.nine_slice",
+  "additionalProperties": false,
+  "description": "The file that specifies 9Slice textures.",
+  "title": "9Slice Texture File",
+  "type": "object",
+  "properties": {
+    "nineslice_size": {
+      "title": "9Slice offsets",
+      "oneOf": [
+        {
+          "description": "Offset from left, top, right and bottom of the texture file.",
+          "type": "number",
+          "minimum": 0
+        },
+        {
+          "description": "Offsets from left, top, right and bottom of the texture file (in this exact order).",
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 4,
+          "items": {
+            "type": "number",
+            "minimum": 0
+          }
+        }
+      ]
+    },
+    "base_size": {
+      "title": "Size of the texture",
+      "description": "Width and height of the texture (in this exact order).",
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": {
+        "type": "number",
+        "minimum": 0
+      }
+    }
+  }
+}

--- a/vscode-settings.json
+++ b/vscode-settings.json
@@ -1,34 +1,23 @@
 {
   "json.schemas": [
     {
-      "fileMatch": [
-        "skin_pack/skins.{json,jsonc,json5}"
-      ],
+      "fileMatch": ["skin_pack/skins.{json,jsonc,json5}"],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/skinpacks/skins.json"
     },
     {
-      "fileMatch": [
-        "language_names.{json,jsonc,json5}"
-      ],
+      "fileMatch": ["language_names.{json,jsonc,json5}"],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/language/language_names.json"
     },
     {
-      "fileMatch": [
-        "languages.{json,jsonc,json5}"
-      ],
+      "fileMatch": ["languages.{json,jsonc,json5}"],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/language/languages.json"
     },
     {
-      "fileMatch": [
-        "manifest.{json,jsonc,json5}"
-      ],
+      "fileMatch": ["manifest.{json,jsonc,json5}"],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/general/manifest.json"
     },
     {
-      "fileMatch": [
-        "world_behavior_packs.{json,jsonc,json5}",
-        "world_resource_packs.{json,jsonc,json5}"
-      ],
+      "fileMatch": ["world_behavior_packs.{json,jsonc,json5}", "world_resource_packs.{json,jsonc,json5}"],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/general/world_x_packs.json"
     },
     {
@@ -64,23 +53,15 @@
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/animations/actor_animation.json"
     },
     {
-      "fileMatch": [
-        "attachables/*.{json,jsonc,json5}",
-        "attachables/**/*.{json,jsonc,json5}",
-        "*.{attachable,attach,at}.{json,jsonc,json5}"
-      ],
+      "fileMatch": ["attachables/*.{json,jsonc,json5}", "attachables/**/*.{json,jsonc,json5}", "*.{attachable,attach,at}.{json,jsonc,json5}"],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/attachables/attachables.json"
     },
     {
-      "fileMatch": [
-        "biomes_client.{json,jsonc,json5}"
-      ],
+      "fileMatch": ["biomes_client.{json,jsonc,json5}"],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/biomes_client.json"
     },
     {
-      "fileMatch": [
-        "blocks.{json,jsonc,json5}"
-      ],
+      "fileMatch": ["blocks.{json,jsonc,json5}"],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/blocks.json"
     },
     {
@@ -94,29 +75,19 @@
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/entity/entity.json"
     },
     {
-      "fileMatch": [
-        "fogs/*.{json,jsonc,json5}",
-        "fogs/**/*.{json,jsonc,json5}",
-        "*.fog.{json,jsonc,json5}"
-      ],
+      "fileMatch": ["fogs/*.{json,jsonc,json5}", "fogs/**/*.{json,jsonc,json5}", "*.fog.{json,jsonc,json5}"],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/fog/fog.json"
     },
     {
-      "fileMatch": [
-        "flipbook_textures.{json,jsonc,json5}"
-      ],
+      "fileMatch": ["flipbook_textures.{json,jsonc,json5}"],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/textures/flipbook_textures.json"
     },
     {
-      "fileMatch": [
-        "item_texture.{json,jsonc,json5}"
-      ],
+      "fileMatch": ["item_texture.{json,jsonc,json5}"],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/textures/item_texture.json"
     },
     {
-      "fileMatch": [
-        "texture_list.{json,jsonc,json5}"
-      ],
+      "fileMatch": ["texture_list.{json,jsonc,json5}"],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/textures/texture_list.json"
     },
     {
@@ -136,57 +107,35 @@
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/items/items.json"
     },
     {
-      "fileMatch": [
-        "models/entity/*.{json,jsonc,json5}",
-        "models/entity/**/*.{json,jsonc,json5}",
-        "*.{geo,geometry,model,g}.{json,jsonc,json5}"
-      ],
+      "fileMatch": ["models/entity/*.{json,jsonc,json5}", "models/entity/**/*.{json,jsonc,json5}", "*.{geo,geometry,model,g}.{json,jsonc,json5}"],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/models/entity/model_entity.json"
     },
     {
-      "fileMatch": [
-        "materials/*.material"
-      ],
+      "fileMatch": ["materials/*.material"],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/materials/materials.json"
     },
     {
-      "fileMatch": [
-        "music_definitions.json"
-      ],
+      "fileMatch": ["music_definitions.json"],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/sounds/music_definitions.json"
     },
     {
-      "fileMatch": [
-        "particles/*.{json,jsonc,json5}",
-        "particles/**/*.{json,jsonc,json5}",
-        "*.{particle,p}.{json,jsonc,json5}"
-      ],
+      "fileMatch": ["particles/*.{json,jsonc,json5}", "particles/**/*.{json,jsonc,json5}", "*.{particle,p}.{json,jsonc,json5}"],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/particles/particles.json"
     },
     {
-      "fileMatch": [
-        "render_controllers/*.{json,jsonc,json5}",
-        "render_controllers/**/*.{json,jsonc,json5}",
-        "*.{render,render_controller,rc}.{json,jsonc,json5}"
-      ],
+      "fileMatch": ["render_controllers/*.{json,jsonc,json5}", "render_controllers/**/*.{json,jsonc,json5}", "*.{render,render_controller,rc}.{json,jsonc,json5}"],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/render_controllers/render_controllers.json"
     },
     {
-      "fileMatch": [
-        "sound_definitions.{json,jsonc,json5}"
-      ],
+      "fileMatch": ["sound_definitions.{json,jsonc,json5}"],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/sounds/sound_definitions.json"
     },
     {
-      "fileMatch": [
-        "sounds.{json,jsonc,json5}"
-      ],
+      "fileMatch": ["sounds.{json,jsonc,json5}"],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/sounds.json"
     },
     {
-      "fileMatch": [
-        "terrain_texture.{json,jsonc,json5}"
-      ],
+      "fileMatch": ["terrain_texture.{json,jsonc,json5}"],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/textures/terrain_texture.json"
     },
     {
@@ -254,9 +203,7 @@
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/behavior/dialogue/dialogue.json"
     },
     {
-      "fileMatch": [
-        "functions/tick.{json,jsonc,json5}"
-      ],
+      "fileMatch": ["functions/tick.{json,jsonc,json5}"],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/behavior/functions/tick.json"
     },
     {
@@ -357,19 +304,11 @@
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/behavior/items/items.json"
     },
     {
-      "fileMatch": [
-        "recipes/*.{json,jsonc,json5}",
-        "recipes/**/*.{json,jsonc,json5}",
-        "*.{recipe,crafting_recipe,cr,r}.{json,jsonc,json5}"
-      ],
+      "fileMatch": ["recipes/*.{json,jsonc,json5}", "recipes/**/*.{json,jsonc,json5}", "*.{recipe,crafting_recipe,cr,r}.{json,jsonc,json5}"],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/behavior/recipes/recipes.json"
     },
     {
-      "fileMatch": [
-        "spawn_rules/*.{json,jsonc,json5}",
-        "spawn_rules/**/*.{json,jsonc,json5}",
-        "*.{spawn,sr,spawn_rule}.{json,jsonc,json5}"
-      ],
+      "fileMatch": ["spawn_rules/*.{json,jsonc,json5}", "spawn_rules/**/*.{json,jsonc,json5}", "*.{spawn,sr,spawn_rule}.{json,jsonc,json5}"],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/behavior/spawn_rules/spawn_rules.json"
     },
     {
@@ -403,6 +342,21 @@
         "*.volume.{json,jsonc,json5}"
       ],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/behavior/volumes/volumes.json"
+    },
+    {
+      "fileMatch": [
+        "resource_packs/*/textures/*/*.{json,jsonc,json5}",
+        "*resource*pack*/textures/*/*.{json,jsonc,json5}",
+        "*Resource*Pack*/textures/*/*.{json,jsonc,json5}",
+        "*RP*/textures/*/*.{json,jsonc,json5}",
+        "*rp*/textures/*/*.{json,jsonc,json5}",
+        "resource_packs/*/textures/*/**/*.{json,jsonc,json5}",
+        "*resource*pack*/textures/*/**/*.{json,jsonc,json5}",
+        "*Resource*Pack*/textures/*/**/*.{json,jsonc,json5}",
+        "*RP*/textures/*/**/*.{json,jsonc,json5}",
+        "*rp*/textures/*/**/*.{json,jsonc,json5}"
+      ],
+      "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/textures/nine_slice.json"
     }
   ]
 }


### PR DESCRIPTION
This Pull Request introduces the 9-Slice schema for textures, a technique that allows creators to make textures that are not only scalable but also minimized in size. The 9-Slice method divides the image into nine sections:
- 4 corners, that are not scaled
- 4 sides, that are scaled in one axis
- center part, that is scaled in both X and Y axis

More detailed explanation on wiki: https://en.wikipedia.org/wiki/9-slice_scaling