### PR TITLE
Add aseprite flipbook schema

### DIFF
--- a/source/resource/textures/aseprite_flipbook.json
+++ b/source/resource/textures/aseprite_flipbook.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "blockception.minecraft.resource.texture.aseprite_flipbook",
+  "additionalProperties": false,
+  "description": "The file that specifies Aseprite/libresprite flipbook animation.",
+  "title": "Aseprite Flipbook File",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "description": "The meta data of the flipbook.",
+      "additionalProperties": true,
+      "properties": {
+        "size": {
+          "type": "object",
+          "description": "The size of the flipbook sprite sheet.",
+          "properties": {
+            "w": {
+              "description": "The width of the sprite sheet.",
+              "type": "integer"
+            },
+            "h": {
+              "description": "The height of the sprite sheet.",
+              "type": "integer"
+            }
+          },
+          "required": ["w", "h"]
+        },
+        "image": {
+          "description": "The path to the sprite sheet. The value is required, but not used.",
+          "type": "string"
+        }
+      },
+      "required": ["size", "image"]
+    },
+    "frames": {
+      "type": "array",
+      "description": "The frames of the flipbook.",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "duration": {
+            "description": "The duration of the frame in milliseconds.",
+            "type": "integer",
+            "minimum": 1
+          },
+          "frame": {
+            "type": "object",
+            "description": "The position of the frame in the sprite sheet (UV).",
+            "properties": {
+              "x": {
+                "type": "integer",
+                "description": "The x position of the frame in the sprite sheet.",
+                "minimum": 0
+              },
+              "y": {
+                "type": "integer",
+                "description": "The y position of the frame in the sprite sheet.",
+                "minimum": 0
+              }
+            },
+            "required": ["x", "y"]
+          }
+        },
+        "required": ["duration", "frame"]
+      }
+    }
+  },
+  "required": ["meta", "frames"]
+}

--- a/source/resource/textures/aseprite_flipbook.json
+++ b/source/resource/textures/aseprite_flipbook.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "blockception.minecraft.resource.texture.aseprite_flipbook",
   "additionalProperties": false,
   "description": "The file that specifies Aseprite/libresprite flipbook animation.",

--- a/source/resource/textures/ui_texture_definition.json
+++ b/source/resource/textures/ui_texture_definition.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "blockception.minecraft.resource.texture.ui_definition",
+  "additionalProperties": false,
+  "description": "The file that specifies either 9slice texture or Aseprite flipbook.",
+  "title": "UI Texture File",
+  "type": "object",
+  "oneOf": [
+    {
+      "$ref": "./nine_slice.json"
+    },
+    {
+      "$ref": "./aseprite_flipbook.json"
+    }
+  ]
+}

--- a/vscode-settings.json
+++ b/vscode-settings.json
@@ -368,7 +368,7 @@
         "*RP*/textures/*/**/*.{json,jsonc,json5}",
         "*rp*/textures/*/**/*.{json,jsonc,json5}"
       ],
-      "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/textures/nine_slice.json"
+      "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/textures/ui_texture_definition.json"
     }
   ]
 }


### PR DESCRIPTION
 - Added Aseprite/libresprite flipbook schema
 - Added UI Texture schema, that points either to 9slice or aseprite flipbook schema
 - Changed schema of json files in textures from `nine_slice` to `ui_texture_definition`