### PR TITLE
Update entity_sensor's schema to 1.20.60

### DIFF
--- a/source/behavior/entities/format/components/entity_sensor.json
+++ b/source/behavior/entities/format/components/entity_sensor.json
@@ -37,6 +37,12 @@
           "title": "Event",
           "description": "event.",
           "type": "string"
+        },
+        "cooldown": {
+          "title": "Cooldown",
+          "description": "How many seconds should elapse before the subsensor can once again sense for entities. The cooldown is applied on top of the base 1 tick (0.05 seconds) delay. Negative values will result in no cooldown being used.",
+          "type": "number",
+          "default": -1
         }
       },
       "examples": [

--- a/source/behavior/entities/format/components/entity_sensor.json
+++ b/source/behavior/entities/format/components/entity_sensor.json
@@ -1,57 +1,93 @@
 {
   "$id": "blockception.minecraft.behavior.entities.minecraft.entity_sensor",
+  "definitions": {
+    "sensor_element": {
+      "type": "object",
+      "title": "Entity Sensor",
+      "additionalProperties": false,
+      "properties": {
+        "maximum_count": {
+          "type": "integer",
+          "default": -1,
+          "description": "The maximum number of entities that must pass the filter conditions for the event to send.",
+          "title": "Maximum Count"
+        },
+        "minimum_count": {
+          "type": "integer",
+          "default": 1,
+          "description": "The minimum number of entities that must pass the filter conditions for the event to send.",
+          "title": "Minimum Count"
+        },
+        "require_all": {
+          "type": "boolean",
+          "default": false,
+          "description": "If true requires all nearby entities to pass the filter conditions for the event to send.",
+          "title": "Require All"
+        },
+        "sensor_range": {
+          "type": "number",
+          "default": 10,
+          "description": "The maximum distance another entity can be from this and have the filters checked against it.",
+          "title": "Sensor Range"
+        },
+        "event_filters": {
+          "$ref": "../../filters/filters.json"
+        },
+        "event": {
+          "title": "Event",
+          "description": "event.",
+          "type": "string"
+        }
+      },
+      "examples": [
+        {
+          "maximum_count": -1,
+          "minimum_count": 1,
+          "require_all": false,
+          "sensor_range": 10,
+          "event": "example"
+        }
+      ]
+    }
+  },
   "type": "object",
   "title": "Entity Sensor",
   "description": "A component that fires an event when a set of conditions are met by other entities within the defined range.",
-  "additionalProperties": false,
-  "properties": {
-    "maximum_count": {
-      "type": "integer",
-      "default": -1,
-      "description": "The maximum number of entities that must pass the filter conditions for the event to send.",
-      "title": "Maximum Count"
-    },
-    "minimum_count": {
-      "type": "integer",
-      "default": 1,
-      "description": "The minimum number of entities that must pass the filter conditions for the event to send.",
-      "title": "Minimum Count"
-    },
-    "relative_range": {
-      "type": "boolean",
-      "default": true,
-      "description": "If true the sensor range is additive on top of the entity's size.",
-      "title": "Relative Range"
-    },
-    "require_all": {
-      "type": "boolean",
-      "default": false,
-      "description": "If true requires all nearby entities to pass the filter conditions for the event to send.",
-      "title": "Require All"
-    },
-    "sensor_range": {
-      "type": "number",
-      "default": 10,
-      "description": "The maximum distance another entity can be from this and have the filters checked against it.",
-      "title": "Sensor Range"
-    },
-    "event_filters": {
-      "$ref": "../../filters/filters.json"
-    },
-    "event": {
-      "title": "Event",
-      "description": "event.",
-      "type": "string"
-    }
-  },
-  "examples": [
+  "oneOf": [
     {
-      "maximum_count": -1,
-      "minimum_count": 1,
-      "relative_range": true,
-      "require_all": false,
-      "sensor_range": 10,
-      "event": "example"
+      "allOf": [
+        {
+          "$ref": "#/definitions/sensor_element"
+        },
+        {
+          "properties": {
+            "relative_range": {
+              "type": "boolean",
+              "default": true,
+              "description": "If true the sensor range is additive on top of the entity's size.",
+              "title": "Relative Range"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "properties": {
+        "subsensors": {
+          "type": "array",
+          "title": "Subsensors",
+          "description": "The list of subsensors.",
+          "items": {
+            "$ref": "#/definitions/sensor_element"
+          }
+        },
+        "relative_range": {
+          "type": "boolean",
+          "default": true,
+          "description": "If true the sensor range is additive on top of the entity's size.",
+          "title": "Relative Range"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
Updated `entity_sensor`'s JSON schema to  change from 1.20.60.21 beta.

From changelog:
 - The "entity_sensor" component now supports multiple "subsensors":
 - "event", "require_all", "minimum_count", "maximum_count", "range" and "event_filter" are now individually configurable fields of each subsensor
 - Subsensors also have a new "cooldown" field, which defines how often each subsensor should sense for entities
 - All these changes require a "format_version" of 1.20.60 or higher
