### PR TITLE
Added full_cube constant to block geometry

### DIFF
--- a/source/behavior/blocks/format/components/geometry.json
+++ b/source/behavior/blocks/format/components/geometry.json
@@ -8,6 +8,17 @@
     },
     {
       "type": "object",
+      "properties": {
+        "identifier": {
+          "title": "Identifier",
+          "description": "The description identifier of the geometry file to use to render this block. This identifier must match an existing geometry identifier in any of the currently loaded resource packs.",
+          "type": "string",
+          "enum": ["minecraft:geometry.full_block"]
+        }
+      }
+    },
+    {
+      "type": "object",
       "additionalProperties": false,
       "required": ["identifier"],
       "properties": {

--- a/source/behavior/blocks/format/components/unit_cube.json
+++ b/source/behavior/blocks/format/components/unit_cube.json
@@ -1,7 +1,7 @@
 {
   "$id": "blockception.minecraft.behavior.blocks.minecraft.unit_cube",
   "title": "Unit Cube",
-  "description": "[Experimental] Specifies that a unit cube is to be used with tessellation.",
+  "description": "[Deprecated][Experimental] Specifies that a unit cube is to be used with tessellation.",
   "type": "object",
   "additionalProperties": false,
   "properties": {}


### PR DESCRIPTION
Modified `minecraft:geometry` block component to include `minecraft:geometry.full_block` as a constant.