### PR TITLE
Support single values for item components

### DIFF
--- a/source/behavior/items/format/components/allow_off_hand.json
+++ b/source/behavior/items/format/components/allow_off_hand.json
@@ -1,12 +1,25 @@
 {
   "$id": "blockception.minecraft.behavior.items.minecraft:allow_off_hand",
-  "additionalProperties": false,
-  "type": "object",
   "title": "Allow Off Hand",
   "description": "The allow off hand component determines whether the item can be placed in the off hand slot of the inventory.",
-  "required": ["value"],
-  "properties": { "value": { "type": "boolean", "title": "Value", "description": "Whether the item can be placed in the off hand slot" } },
-  "examples": [
-    { "value": true }
+  "default": false,
+  "examples": [true, { "value": true }],
+  "oneOf": [
+    {
+      "type": "boolean"
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value"],
+      "properties": {
+        "value": {
+          "title": "Value",
+          "description": "Whether the item can be placed in the off hand slot",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    }
   ]
 }

--- a/source/behavior/items/format/components/can_destroy_in_creative.json
+++ b/source/behavior/items/format/components/can_destroy_in_creative.json
@@ -1,12 +1,25 @@
 {
   "$id": "blockception.minecraft.behavior.items.minecraft:can_destroy_in_creative",
-  "additionalProperties": false,
-  "type": "object",
   "title": "Can Destroy In Creative",
   "description": "The can destroy in creative component determines if the item will break blocks in creative when swinging.",
-  "required": ["value"],
-  "properties": { "value": { "type": "boolean", "title": "Value", "description": "Whether the item can destroy blocks while in creative" } },
-  "examples": [
-    { "value": false }
+  "default": true,
+  "examples": [false, { "value": false }],
+  "oneOf": [
+    {
+      "type": "boolean"
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value"],
+      "properties": {
+        "value": {
+          "title": "Value",
+          "description": "Whether the item can destroy blocks while in creative",
+          "type": "boolean",
+          "default": true
+        }
+      }
+    }
   ]
 }

--- a/source/behavior/items/format/components/display_name.json
+++ b/source/behavior/items/format/components/display_name.json
@@ -2,11 +2,10 @@
   "$id": "blockception.minecraft.behavior.items.minecraft:display_name",
   "title": "Display Name",
   "description": "Display Name item component. Display Names display the name of an item.",
+  "$comment": "Does not currently support single value parsing.",
   "type": "object",
   "additionalProperties": false,
   "required": ["value"],
   "properties": { "value": { "type": "string", "title": "Value", "description": "Set the display name for an item." } },
-  "examples": [
-    { "value": "secret_weapon"}
-  ]
+  "examples": [{ "value": "secret_weapon" }]
 }

--- a/source/behavior/items/format/components/glint.json
+++ b/source/behavior/items/format/components/glint.json
@@ -1,12 +1,25 @@
 {
   "$id": "blockception.minecraft.behavior.items.minecraft:foil",
-  "additionalProperties": false,
-  "type": "object",
   "title": "Glint",
   "description": "The glint component determines whether the item has the enchanted glint render effect on it",
-  "required": ["value"],
-  "properties": { "value": { "type": "boolean", "title": "Value", "description": "Whether the item has the glint effect." } },
-  "examples": [
-    { "value": true }
+  "default": false,
+  "examples": [true, { "value": true }],
+  "oneOf": [
+    {
+      "type": "boolean"
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value"],
+      "properties": {
+        "value": {
+          "title": "Value",
+          "description": "Whether the item has the glint effect.",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    }
   ]
 }

--- a/source/behavior/items/format/components/hand_equipped.json
+++ b/source/behavior/items/format/components/hand_equipped.json
@@ -1,12 +1,25 @@
 {
   "$id": "blockception.minecraft.behavior.items.minecraft:hand_equipped",
-  "additionalProperties": false,
-  "type": "object",
   "title": "Hand Equipped",
   "description": "This component determines if an item is rendered like a tool while in hand.",
-  "required": ["value"],
-  "properties": { "value": { "type": "boolean", "title": "Value", "description": "If the item is rendered like a tool while in hand." } },
-  "examples": [
-    { "value": true }
+  "default": false,
+  "examples": [true, { "value": true }],
+  "oneOf": [
+    {
+      "type": "boolean"
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value"],
+      "properties": {
+        "value": {
+          "title": "Value",
+          "description": "If the item is rendered like a tool while in hand.",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    }
   ]
 }

--- a/source/behavior/items/format/components/hover_text_color.json
+++ b/source/behavior/items/format/components/hover_text_color.json
@@ -1,19 +1,28 @@
 {
   "$id": "blockception.minecraft.behavior.items.minecraft:hover_text_color",
-  "additionalProperties": false,
-  "type": "object",
   "title": "Hover Text Color",
   "description": "The hover text color component determines the color of the item name when hovering over it.",
-  "required": ["value"],
-  "properties": { 
-    "value": {
-      "description": "The color of the item's hover text.",
-      "type": "string",
-      "enum": ["black", "blue", "brown", "cyan", "gray", "green", "light_blue", "light_green", "magenta", "orange", "pink", "purple", "red", "silver", "white", "yellow"],
-      "title": "Value"
+  "examples": ["light_blue", { "value": "light_blue" }],
+  "definitions": {
+    "color": {
+      "enum": ["black", "blue", "brown", "cyan", "gray", "green", "light_blue", "light_green", "magenta", "orange", "pink", "purple", "red", "silver", "white", "yellow"]
     }
-   },
-  "examples": [
-    { "value": "light_blue" }
+  },
+  "oneOf": [
+    {
+      "$ref": "#/definitions/color"
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value"],
+      "properties": {
+        "value": {
+          "title": "Value",
+          "description": "The color of the item's hover text.",
+          "$ref": "#/definitions/color"
+        }
+      }
+    }
   ]
 }

--- a/source/behavior/items/format/components/icon.json
+++ b/source/behavior/items/format/components/icon.json
@@ -2,26 +2,31 @@
   "$id": "blockception.minecraft.behavior.items.minecraft:icon",
   "title": "Icon",
   "description": "The icon item componenent determines the icon to represent the item in the UI and elsewhere.",
-  "type": "object",
-  "additionalProperties": true,
-  "required": ["textures"],
-  "properties": {
-    "textures": {
-      "title": "Textures",
-      "description": "Contains key-value pairs of textures used by the item",
-      "type": "object", 
+  "examples": ["stick", { "textures": { "default": "stick" } }],
+  "oneOf": [
+    {
+      "type": "string"
+    },
+    {
+      "type": "object",
       "additionalProperties": true,
-      "required": ["default"],
+      "required": ["textures"],
       "properties": {
-        "default": {
-          "type": "string",
-          "title": "Default Texture",
-          "description": "The key from the resource_pack/textures/item_texture.json `texture_data` object associated with the texture file Example: blaze_powder."
+        "textures": {
+          "title": "Textures",
+          "description": "Contains key-value pairs of textures used by the item",
+          "type": "object",
+          "additionalProperties": true,
+          "required": ["default"],
+          "properties": {
+            "default": {
+              "type": "string",
+              "title": "Default Texture",
+              "description": "The key from the resource_pack/textures/item_texture.json `texture_data` object associated with the texture file Example: blaze_powder."
+            }
+          }
         }
       }
     }
-  },
-  "examples": [
-    {"textures": {"default": "stick"}}
   ]
 }

--- a/source/behavior/items/format/components/liquid_clipped.json
+++ b/source/behavior/items/format/components/liquid_clipped.json
@@ -1,12 +1,25 @@
 {
   "$id": "blockception.minecraft.behavior.items.minecraft:liquid_clipped",
-  "additionalProperties": false,
-  "type": "object",
   "title": "Liquid Clipped",
   "description": "The liquid clipped component determines whether the item interacts with liquid blocks on use.",
-  "required": ["value"],
-  "properties": { "value": { "type": "boolean", "title": "Value", "description": "Whether the item interacts with liquid blocks on use." } },
-  "examples": [
-    { "value": true }
+  "default": false,
+  "examples": [true, { "value": true }],
+  "oneOf": [
+    {
+      "type": "boolean"
+    },
+    {
+      "additionalProperties": false,
+      "type": "object",
+      "required": ["value"],
+      "properties": {
+        "value": {
+          "title": "Value",
+          "description": "Whether the item interacts with liquid blocks on use.",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    }
   ]
 }

--- a/source/behavior/items/format/components/max_stack_size.json
+++ b/source/behavior/items/format/components/max_stack_size.json
@@ -1,12 +1,29 @@
 {
   "$id": "blockception.minecraft.behavior.items.minecraft:max_stack_size",
-  "additionalProperties": false,
-  "type": "object",
   "title": "Max Stack Size",
   "description": "The max stack size component determines how many of the item can be stacked together.",
-  "required": ["value"],
-  "properties": { "value": { "type": "number", "title": "Value", "description": "How many of the item that can be stacked.", "default": 64, "minimum": 1 } },
-  "examples": [
-    { "value": 1 }
+  "default": 64,
+  "examples": [1, { "value": 1 }],
+  "oneOf": [
+    {
+      "type": "number",
+      "minimum": 1,
+      "maximum": 64
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value"],
+      "properties": {
+        "value": {
+          "title": "Value",
+          "description": "How many of the item that can be stacked.",
+          "type": "number",
+          "default": 64,
+          "minimum": 1,
+          "maximum": 64
+        }
+      }
+    }
   ]
 }

--- a/source/behavior/items/format/components/should_despawn.json
+++ b/source/behavior/items/format/components/should_despawn.json
@@ -2,11 +2,24 @@
   "$id": "blockception.minecraft.behavior.items.minecraft:should_despawn",
   "title": "Should Despawn",
   "description": "Should despawn component determines if the item should eventually despawn while floating in the world",
-  "additionalProperties": false,
-  "type": "object",
-  "required": ["value"],
-  "properties": { "value": { "type": "boolean", "title": "Value", "description": "Whether the item should eventually despawn while floating in the world" } },
-  "examples": [
-    { "value": false }
+  "default": true,
+  "examples": [false, { "value": false }],
+  "oneOf": [
+    {
+      "type": "boolean"
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value"],
+      "properties": {
+        "value": {
+          "title": "Value",
+          "description": "Whether the item should eventually despawn while floating in the world",
+          "type": "boolean",
+          "default": true
+        }
+      }
+    }
   ]
 }

--- a/source/behavior/items/format/components/stacked_by_data.json
+++ b/source/behavior/items/format/components/stacked_by_data.json
@@ -2,11 +2,24 @@
   "$id": "blockception.minecraft.behavior.items.minecraft:stacked_by_data",
   "title": "Stacked By Data",
   "description": "The stacked by data component determines if the same item with different aux values can stack.",
-  "additionalProperties": false,
-  "type": "object",
-  "required": ["value"],
-  "properties": { "value": { "type": "boolean", "title": "Value", "description": "Also defines whether the item actors can merge while floating in the world." } },
-  "examples": [
-    { "value": true }
+  "default": false,
+  "examples": [true, { "value": true }],
+  "oneOf": [
+    {
+      "type": "boolean"
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value"],
+      "properties": {
+        "value": {
+          "title": "Value",
+          "description": "Also defines whether the item actors can merge while floating in the world.",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    }
   ]
 }

--- a/source/behavior/items/format/components/use_animation.json
+++ b/source/behavior/items/format/components/use_animation.json
@@ -1,21 +1,25 @@
 {
-    "$id": "blockception.minecraft.behavior.items.minecraft:use_animation",
-    "additionalProperties": false,
-    "required": [ "value" ],
-    "type": "object",
-    "title": "Use Animation",
-    "description": "This component determines which animation plays when using the item.",
-    "properties": {
-        "value": {
-            "title": "Value",
-            "description": "Which animation to play when using the item.",
-            "enum": [
-                "bow",
-                "eat",
-                "crossbow",
-                "drink",
-                "camera"
-            ]
-        }
+  "$id": "blockception.minecraft.behavior.items.minecraft:use_animation",
+  "title": "Use Animation",
+  "description": "This component determines which animation plays when using the item.",
+  "definitions": {
+    "animation": {
+      "enum": ["bow", "brush", "camera", "crossbow", "drink", "eat", "none", "spear", "spyglass"]
     }
+  },
+  "oneOf": [
+    { "$ref": "#/definitions/animation" },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value"],
+      "properties": {
+        "value": {
+          "title": "Value",
+          "description": "Which animation to play when using the item.",
+          "$ref": "#/definitions/animation"
+        }
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Many item components also support a format similar to `"minecraft:component": true` rather than `"minecraft:component": { "value": true }`