### PR TITLE
Remove "commands" Menu Category

### DIFF
--- a/source/general/vanilla/creative_category.json
+++ b/source/general/vanilla/creative_category.json
@@ -1,14 +1,7 @@
 {
-    "$id": "blockception.minecraft.general.vanilla.creative_category",
-    "type": "string",
-    "title": "Category",
-    "description": "Determines which category this block/item will be placed under in the inventory and crafting table container screens.",
-    "enum": [
-        "nature",
-		"construction",
-		"items",
-		"equipment",
-		"none",
-		"commands"
-    ]
+  "$id": "blockception.minecraft.general.vanilla.creative_category",
+  "type": "string",
+  "title": "Category",
+  "description": "Determines which category this block/item will be placed under in the inventory and crafting table container screens.",
+  "enum": ["construction", "equipment", "items", "nature", "none"]
 }


### PR DESCRIPTION
It doesn't exist and will result in a content error if used.