### PR TITLE
Correct name of "textures_list.json"

### DIFF
--- a/source/compress_specification.json
+++ b/source/compress_specification.json
@@ -16,7 +16,7 @@
     { "Source": "./resource/fog/fog.json", "Destination": "../resource/fog/fog.json" },
     { "Source": "./resource/textures/flipbook_textures.json", "Destination": "../resource/textures/flipbook_textures.json" },
     { "Source": "./resource/textures/item_texture.json", "Destination": "../resource/textures/item_texture.json" },
-    { "Source": "./resource/textures/texture_list.json", "Destination": "../resource/textures/texture_list.json" },
+    { "Source": "./resource/textures/textures_list.json", "Destination": "../resource/textures/textures_list.json" },
     { "Source": "./resource/textures/texture_set.json", "Destination": "../resource/textures/texture_set.json" },
     { "Source": "./resource/items/items.json", "Destination": "../resource/items/items.json" },
     { "Source": "./resource/models/entity/model_entity.json", "Destination": "../resource/models/entity/model_entity.json" },

--- a/source/resource/textures/texture_list.json
+++ b/source/resource/textures/texture_list.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "http://json-schema.org/draft-07/schema",
-  "title": "Texture List",
-  "description": "A list of texture to load in.",
-  "type": "array",
-  "items": { "title": "Filepath", "type": "string", "pattern": "^textures/", "examples": ["textures/blocks/"] }
-}

--- a/source/resource/textures/textures_list.json
+++ b/source/resource/textures/textures_list.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "title": "Textures List",
+  "description": "List texture files included in this pack to reduce loading times.",
+  "type": "array",
+  "items": {
+    "title": "Filepath",
+    "type": "string",
+    "pattern": "^textures/",
+    "examples": ["textures/blocks/"]
+  }
+}

--- a/vscode-settings.json
+++ b/vscode-settings.json
@@ -91,8 +91,8 @@
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/textures/item_texture.json"
     },
     {
-      "fileMatch": ["texture_list.{json,jsonc,json5}"],
-      "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/textures/texture_list.json"
+      "fileMatch": ["textures_list.{json,jsonc,json5}"],
+      "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/textures/textures_list.json"
     },
     {
       "fileMatch": ["*.texture_set.{json,jsonc,json5}"],


### PR DESCRIPTION
Added an "s" to match the following pages:
- [Getting Started with Deferred Lighting | Microsoft Learn](https://learn.microsoft.com/en-us/minecraft/creator/documents/deferredlighting?view=minecraft-bedrock-stable#deferred-lighting-json-files)
  
  ![image](https://github.com/Blockception/Minecraft-bedrock-json-schemas/assets/79767058/b9d80ad7-3036-4155-80de-4fe2adac4a37)

- [textures_list.json | Bedrock Wiki](https://wiki.bedrock.dev/concepts/textures-list)