### PR TITLE
Fix ingredients in shapeless recipe schema

### DIFF
--- a/source/behavior/recipes/types/recipe_shapeless.json
+++ b/source/behavior/recipes/types/recipe_shapeless.json
@@ -12,7 +12,8 @@
     "ingredients": {
       "description": "Items used as input (without a shape) for the recipe.",
       "title": "Ingredients",
-      "oneOf": [{ "$ref": "./base types/item.json" }, { "type": "array", "items": { "$ref": "./base types/item.json" } }]
+      "type": "array",
+      "items": { "$ref": "./base types/item.json" }
     },
     "group": { "type": "string", "title": "Group", "description": "UNDOCUMENTED.", "$comment": "UNDOCUMENTED" },
     "priority": { "type": "integer", "description": "Item used as output for the furnace recipe.", "title": "Priority" },


### PR DESCRIPTION
Shapeless recipes in 1.21.30 don't seem to support not using any array for ingredients. This changes that, reducing confusion as to why recipes might not be working, especially when only using one ingredient, and getting rid of the annoying "Matches multiple schemas when only one must validate." when using the correct syntax.

Fixed after first PR that edited compiled files