### PR TITLE
Stricter file path matching for schemas

### DIFF
--- a/vscode-settings.json
+++ b/vscode-settings.json
@@ -53,11 +53,35 @@
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/animations/actor_animation.json"
     },
     {
-      "fileMatch": ["block_culling/*.{json,jsonc,json5}", "block_culling/**/*.{json,jsonc,json5}", "*.{cull}.{json,jsonc,json5}"],
+      "fileMatch": [
+        "resource_packs/*/block_culling/*.{json,jsonc,json5}",
+        "*resource*pack*/block_culling/*.{json,jsonc,json5}",
+        "*Resource*Pack*/block_culling/*.{json,jsonc,json5}",
+        "*RP*/block_culling/*.{json,jsonc,json5}",
+        "*rp*/block_culling/*.{json,jsonc,json5}",
+        "resource_packs/*/block_culling/**/*.{json,jsonc,json5}",
+        "*resource*pack*/block_culling/**/*.{json,jsonc,json5}",
+        "*Resource*Pack*/block_culling/**/*.{json,jsonc,json5}",
+        "*RP*/block_culling/**/*.{json,jsonc,json5}",
+        "*rp*/block_culling/**/*.{json,jsonc,json5}",
+        "*.{cull}.{json,jsonc,json5}"
+      ],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/block_culling/block_culling.json"
     },
     {
-      "fileMatch": ["attachables/*.{json,jsonc,json5}", "attachables/**/*.{json,jsonc,json5}", "*.{attachable,attach,at}.{json,jsonc,json5}"],
+      "fileMatch": [
+        "resource_packs/*/attachables/*.{json,jsonc,json5}",
+        "*resource*pack*/attachables/*.{json,jsonc,json5}",
+        "*Resource*Pack*/attachables/*.{json,jsonc,json5}",
+        "*RP*/attachables/*.{json,jsonc,json5}",
+        "*rp*/attachables/*.{json,jsonc,json5}",
+        "resource_packs/*/attachables/**/*.{json,jsonc,json5}",
+        "*resource*pack*/attachables/**/*.{json,jsonc,json5}",
+        "*Resource*Pack*/attachables/**/*.{json,jsonc,json5}",
+        "*RP*/attachables/**/*.{json,jsonc,json5}",
+        "*rp*/attachables/**/*.{json,jsonc,json5}",
+        "*.{attachable,attach,at}.{json,jsonc,json5}"
+      ],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/attachables/attachables.json"
     },
     {
@@ -103,7 +127,19 @@
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/entity/entity.json"
     },
     {
-      "fileMatch": ["fogs/*.{json,jsonc,json5}", "fogs/**/*.{json,jsonc,json5}", "*.fog.{json,jsonc,json5}"],
+      "fileMatch": [
+        "resource_packs/*/fogs/*.{json,jsonc,json5}",
+        "*resource*pack*/fogs/*.{json,jsonc,json5}",
+        "*Resource*Pack*/fogs/*.{json,jsonc,json5}",
+        "*RP*/fogs/*.{json,jsonc,json5}",
+        "*rp*/fogs/*.{json,jsonc,json5}",
+        "resource_packs/*/fogs/**/*.{json,jsonc,json5}",
+        "*resource*pack*/fogs/**/*.{json,jsonc,json5}",
+        "*Resource*Pack*/fogs/**/*.{json,jsonc,json5}",
+        "*RP*/fogs/**/*.{json,jsonc,json5}",
+        "*rp*/fogs/**/*.{json,jsonc,json5}",
+        "*.fog.{json,jsonc,json5}"
+      ],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/fog/fog.json"
     },
     {
@@ -139,7 +175,19 @@
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/items/items.json"
     },
     {
-      "fileMatch": ["models/entity/*.{json,jsonc,json5}", "models/entity/**/*.{json,jsonc,json5}", "*.{geo,geometry,model,g}.{json,jsonc,json5}"],
+      "fileMatch": [
+        "resource_packs/*/models/*.{json,jsonc,json5}",
+        "*resource*pack*/models/*.{json,jsonc,json5}",
+        "*Resource*Pack*/models/*.{json,jsonc,json5}",
+        "*RP*/models/*.{json,jsonc,json5}",
+        "*rp*/models/*.{json,jsonc,json5}",
+        "resource_packs/*/models/**/*.{json,jsonc,json5}",
+        "*resource*pack*/models/**/*.{json,jsonc,json5}",
+        "*Resource*Pack*/models/**/*.{json,jsonc,json5}",
+        "*RP*/models/**/*.{json,jsonc,json5}",
+        "*rp*/models/**/*.{json,jsonc,json5}",
+        "*.{geo,geometry,model,g}.{json,jsonc,json5}"
+      ],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/models/entity/model_entity.json"
     },
     {
@@ -151,11 +199,35 @@
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/sounds/music_definitions.json"
     },
     {
-      "fileMatch": ["particles/*.{json,jsonc,json5}", "particles/**/*.{json,jsonc,json5}", "*.{particle,p}.{json,jsonc,json5}"],
+      "fileMatch": [
+        "resource_packs/*/particles/*.{json,jsonc,json5}",
+        "*resource*pack*/particles/*.{json,jsonc,json5}",
+        "*Resource*Pack*/particles/*.{json,jsonc,json5}",
+        "*RP*/particles/*.{json,jsonc,json5}",
+        "*rp*/particles/*.{json,jsonc,json5}",
+        "resource_packs/*/particles/**/*.{json,jsonc,json5}",
+        "*resource*pack*/particles/**/*.{json,jsonc,json5}",
+        "*Resource*Pack*/particles/**/*.{json,jsonc,json5}",
+        "*RP*/particles/**/*.{json,jsonc,json5}",
+        "*rp*/particles/**/*.{json,jsonc,json5}",
+        "*.{particle,p}.{json,jsonc,json5}"
+      ],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/particles/particles.json"
     },
     {
-      "fileMatch": ["render_controllers/*.{json,jsonc,json5}", "render_controllers/**/*.{json,jsonc,json5}", "*.{render,render_controller,rc}.{json,jsonc,json5}"],
+      "fileMatch": [
+        "resource_packs/*/render_controllers/*.{json,jsonc,json5}",
+        "*resource*pack*/render_controllers/*.{json,jsonc,json5}",
+        "*Resource*Pack*/render_controllers/*.{json,jsonc,json5}",
+        "*RP*/render_controllers/*.{json,jsonc,json5}",
+        "*rp*/render_controllers/*.{json,jsonc,json5}",
+        "resource_packs/*/render_controllers/**/*.{json,jsonc,json5}",
+        "*resource*pack*/render_controllers/**/*.{json,jsonc,json5}",
+        "*Resource*Pack*/render_controllers/**/*.{json,jsonc,json5}",
+        "*RP*/render_controllers/**/*.{json,jsonc,json5}",
+        "*rp*/render_controllers/**/*.{json,jsonc,json5}",
+        "*.{render,render_controller,rc}.{json,jsonc,json5}"
+      ],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/render_controllers/render_controllers.json"
     },
     {
@@ -179,7 +251,20 @@
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/ui/_global_variables.json"
     },
     {
-      "fileMatch": ["ui/*.{json,jsonc,json5}", "ui/**/*.{json,jsonc,json5}", "!ui/_ui_defs.{json,jsonc,json5}", "!ui/_global_variables.{json,jsonc,json5}"],
+      "fileMatch": [
+        "resource_packs/*/ui/*.{json,jsonc,json5}",
+        "*resource*pack*/ui/*.{json,jsonc,json5}",
+        "*Resource*Pack*/ui/*.{json,jsonc,json5}",
+        "*RP*/ui/*.{json,jsonc,json5}",
+        "*rp*/items/*.{json,jsonc,json5}",
+        "resource_packs/*/ui/**/*.{json,jsonc,json5}",
+        "*resource*pack*/ui/**/*.{json,jsonc,json5}",
+        "*Resource*Pack*/ui/**/*.{json,jsonc,json5}",
+        "*RP*/ui/**/*.{json,jsonc,json5}",
+        "*rp*/ui/**/*.{json,jsonc,json5}",
+        "!ui/_ui_defs.{json,jsonc,json5}",
+        "!ui/_global_variables.{json,jsonc,json5}"
+      ],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/ui/ui.json"
     },
     {
@@ -284,7 +369,13 @@
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/behavior/entities/entities.json"
     },
     {
-      "fileMatch": ["functions/tick.{json,jsonc,json5}"],
+      "fileMatch": [
+        "behavior_packs/functions/tick.{json,jsonc,json5}",
+        "*behavior*pack*/functions/tick.{json,jsonc,json5}",
+        "*Behavior*Pack*/functions/tick.{json,jsonc,json5}",
+        "*BP*/functions/tick.{json,jsonc,json5}",
+        "*bp*/functions/tick.{json,jsonc,json5}"
+      ],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/behavior/functions/tick.json"
     },
     {
@@ -344,7 +435,19 @@
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/behavior/items/items.json"
     },
     {
-      "fileMatch": ["recipes/*.{json,jsonc,json5}", "recipes/**/*.{json,jsonc,json5}", "*.{recipe,crafting_recipe,cr,r}.{json,jsonc,json5}"],
+      "fileMatch": [
+        "behavior_packs/*/recipes/*.{json,jsonc,json5}",
+        "*behavior*pack*/recipes/*.{json,jsonc,json5}",
+        "*Behavior*Pack*/recipes/*.{json,jsonc,json5}",
+        "*BP*/recipes/*.{json,jsonc,json5}",
+        "*bp*/recipes/*.{json,jsonc,json5}",
+        "behavior_packs/*/recipes/**/*.{json,jsonc,json5}",
+        "*behavior*pack*/recipes/**/*.{json,jsonc,json5}",
+        "*Behavior*Pack*/recipes/**/*.{json,jsonc,json5}",
+        "*BP*/recipes/**/*.{json,jsonc,json5}",
+        "*bp*/recipes/**/*.{json,jsonc,json5}",
+        "*.{recipe,crafting_recipe,cr,r}.{json,jsonc,json5}"
+      ],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/behavior/recipes/recipes.json"
     },
     {
@@ -364,7 +467,19 @@
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/behavior/loot_tables/loot_tables.json"
     },
     {
-      "fileMatch": ["spawn_rules/*.{json,jsonc,json5}", "spawn_rules/**/*.{json,jsonc,json5}", "*.{spawn,sr,spawn_rule}.{json,jsonc,json5}"],
+      "fileMatch": [
+        "behavior_packs/*/spawn_rules/*.{json,jsonc,json5}",
+        "*behavior*pack*/spawn_rules/*.{json,jsonc,json5}",
+        "*Behavior*Pack*/spawn_rules/*.{json,jsonc,json5}",
+        "*BP*/spawn_rules/*.{json,jsonc,json5}",
+        "*bp*/spawn_rules/*.{json,jsonc,json5}",
+        "behavior_packs/*/spawn_rules/**/*.{json,jsonc,json5}",
+        "*behavior*pack*/spawn_rules/**/*.{json,jsonc,json5}",
+        "*Behavior*Pack*/spawn_rules/**/*.{json,jsonc,json5}",
+        "*BP*/spawn_rules/**/*.{json,jsonc,json5}",
+        "*bp*/spawn_rules/**/*.{json,jsonc,json5}",
+        "*.{spawn,sr,spawn_rule}.{json,jsonc,json5}"
+      ],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/behavior/spawn_rules/spawn_rules.json"
     },
     {


### PR DESCRIPTION
To prevent stuff like models/attachable/file.json being considered an attachable file.