### PR TITLE
Improve texture set schema

### DIFF
--- a/source/resource/textures/texture_set.json
+++ b/source/resource/textures/texture_set.json
@@ -39,33 +39,13 @@
         { "type": "string" },
         {
           "type": "array",
-          "items": [
-            {
-              "title": "Red",
-              "type": "integer",
-              "minimum": 0,
-              "maximum": 255
-            },
-            {
-              "title": "Green",
-              "type": "integer",
-              "minimum": 0,
-              "maximum": 255
-            },
-            {
-              "title": "Blue",
-              "type": "integer",
-              "minimum": 0,
-              "maximum": 255
-            },
-            {
-              "title": "Alpha",
-              "type": "integer",
-              "default": 255,
-              "minimum": 0,
-              "maximum": 255
-            }
-          ]
+          "minItems": 4,
+          "maxItems": 4,
+          "items": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+          }
         }
       ]
     },
@@ -95,26 +75,13 @@
         { "type": "string" },
         {
           "type": "array",
-          "items": [
-            {
-              "title": "Red",
-              "type": "integer",
-              "minimum": 0,
-              "maximum": 255
-            },
-            {
-              "title": "Green",
-              "type": "integer",
-              "minimum": 0,
-              "maximum": 255
-            },
-            {
-              "title": "Blue",
-              "type": "integer",
-              "minimum": 0,
-              "maximum": 255
-            }
-          ]
+          "minItems": 3,
+          "maxItems": 3,
+          "items": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+          }
         }
       ]
     },

--- a/source/resource/textures/texture_set.json
+++ b/source/resource/textures/texture_set.json
@@ -4,7 +4,13 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "format_version": { "$ref": "../../general/format_version.json" },
+    "format_version": {
+      "format_version": {
+        "title": "Format Version",
+        "description": "A version that tells minecraft what type of data format can be expected when reading this file.",
+        "enum": ["1.16.100", "1.21.30"]
+      }
+    },
     "minecraft:texture_set": {
       "title": "Texture Set",
       "description": "Texture Sets are used to define multiple PBR layers for a texture resource.",

--- a/source/resource/textures/texture_set.json
+++ b/source/resource/textures/texture_set.json
@@ -3,6 +3,7 @@
   "$id": "blockception.minecraft.resource.texture.texture_set",
   "type": "object",
   "additionalProperties": false,
+  "required": ["format_version", "minecraft:texture_set"],
   "properties": {
     "format_version": {
       "format_version": {

--- a/source/resource/textures/texture_set.json
+++ b/source/resource/textures/texture_set.json
@@ -15,6 +15,7 @@
         "color": { "$ref": "#/definitions/color" },
         "heightmap": { "$ref": "#/definitions/heightmap" },
         "metalness_emissive_roughness": { "$ref": "#/definitions/mer" },
+        "metalness_emissive_roughness_subsurface": { "$ref": "#/definitions/mers" },
         "normal": { "$ref": "#/definitions/normal" }
       }
     }
@@ -104,6 +105,24 @@
               "maximum": 255
             }
           ]
+        }
+      ]
+    },
+    "mers": {
+      "title": "Metalness Emissive Roughness Subsurface",
+      "description": "This is a 4-channel image or a 4-value array for a uniform MERS. RGBA images map Red to Metalness, Green to Emissive, Blue to Roughness and Alpha to Subsurface.",
+      "examples": [[255, 255, 255, 255]],
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 4,
+          "items": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+          }
         }
       ]
     }

--- a/source/resource/textures/texture_set.json
+++ b/source/resource/textures/texture_set.json
@@ -101,11 +101,6 @@
         }
       ]
     },
-    "normal": {
-      "title": "Normal Map",
-      "description": "This is a 3-channel normal map image (or 4-channel where the 4th channel is ignored). This layer and the \"heightmap\" layer should not both be defined at the same time.",
-      "$ref": "#/definitions/file_name"
-    },
     "heightmap": {
       "title": "Heightmap",
       "description": "1-channel layer image or a single value in this JSON file for a uniform heightmap. This layer and the \"normal\" layer should not both be defined at the same time.",
@@ -144,6 +139,11 @@
           "$ref": "#/definitions/rgba"
         }
       ]
+    },
+    "normal": {
+      "title": "Normal Map",
+      "description": "This is a 3-channel normal map image (or 4-channel where the 4th channel is ignored). This layer and the \"heightmap\" layer should not both be defined at the same time.",
+      "$ref": "#/definitions/file_name"
     }
   }
 }

--- a/source/resource/textures/texture_set.json
+++ b/source/resource/textures/texture_set.json
@@ -6,11 +6,9 @@
   "required": ["format_version", "minecraft:texture_set"],
   "properties": {
     "format_version": {
-      "format_version": {
-        "title": "Format Version",
-        "description": "A version that tells minecraft what type of data format can be expected when reading this file.",
-        "enum": ["1.16.100", "1.21.30"]
-      }
+      "title": "Format Version",
+      "description": "A version that tells minecraft what type of data format can be expected when reading this file.",
+      "enum": ["1.16.100", "1.21.30"]
     },
     "minecraft:texture_set": {
       "title": "Texture Set",

--- a/source/resource/textures/texture_set.json
+++ b/source/resource/textures/texture_set.json
@@ -11,6 +11,16 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["color"],
+      "not": {
+        "anyOf": [
+          {
+            "required": ["heightmap", "normal"]
+          },
+          {
+            "required": ["metalness_emissive_roughness", "metalness_emissive_roughness_subsurface"]
+          }
+        ]
+      },
       "properties": {
         "color": { "$ref": "#/definitions/color" },
         "heightmap": { "$ref": "#/definitions/heightmap" },

--- a/source/resource/textures/texture_set.json
+++ b/source/resource/textures/texture_set.json
@@ -31,46 +31,22 @@
     }
   },
   "definitions": {
-    "color": {
-      "title": "Color",
-      "description": "This is an RGB 3-channel image (defaults to uniform alpha of 1.0), or an RGBA 4-channel image, or a 4 value array for a uniform color with alpha.",
-      "examples": [[255, 255, 255, 255]],
-      "oneOf": [
-        { "type": "string" },
+    "file_name": {
+      "type": "string",
+      "defaultSnippets": [
         {
-          "type": "array",
-          "minItems": 4,
-          "maxItems": 4,
-          "items": {
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 255
-          }
+          "label": "File Name",
+          "body": "${1:${TM_FILENAME_BASE}}"
         }
       ]
     },
-    "normal": {
-      "title": "Normal Map",
-      "description": "This is a 3-channel normal map image (or 4-channel where the 4th channel is ignored). This layer and the \"heightmap\" layer should not both be defined at the same time.",
-      "type": "string"
-    },
-    "heightmap": {
-      "title": "Heightmap",
-      "description": "1-channel layer image or a single value in this JSON file for a uniform heightmap. This layer and the \"normal\" layer should not both be defined at the same time.",
-      "examples": [255],
-      "oneOf": [
-        { "type": "string" },
+    "rgb": {
+      "defaultSnippets": [
         {
-          "type": "integer",
-          "minimum": 0,
-          "maximum": 255
+          "label": "RGB Color",
+          "body": "#${1:RR}${2:GG}${3:BB}"
         }
-      ]
-    },
-    "mer": {
-      "title": "Metalness Emissive Roughness",
-      "description": "This is a 3-channel image (or 4-channel where the 4th channel is ignored) or a 3-value array for a uniform MER. RGB images map Red to Metalness, Green to Emissive, and Blue to Roughness.",
-      "examples": [[255, 255, 255]],
+      ],
       "oneOf": [
         { "type": "string" },
         {
@@ -85,10 +61,13 @@
         }
       ]
     },
-    "mers": {
-      "title": "Metalness Emissive Roughness Subsurface",
-      "description": "This is a 4-channel image or a 4-value array for a uniform MERS. RGBA images map Red to Metalness, Green to Emissive, Blue to Roughness and Alpha to Subsurface.",
-      "examples": [[255, 255, 255, 255]],
+    "rgba": {
+      "defaultSnippets": [
+        {
+          "label": "ARGB Color",
+          "body": "#${1:AA}${2:RR}${3:GG}${4:BB}"
+        }
+      ],
       "oneOf": [
         { "type": "string" },
         {
@@ -100,6 +79,62 @@
             "minimum": 0,
             "maximum": 255
           }
+        }
+      ]
+    },
+    "color": {
+      "title": "Color",
+      "description": "This is an RGB 3-channel image (defaults to uniform alpha of 1.0), or an RGBA 4-channel image, or a 4 value array for a uniform color with alpha.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/file_name"
+        },
+        {
+          "$ref": "#/definitions/rgba"
+        }
+      ]
+    },
+    "normal": {
+      "title": "Normal Map",
+      "description": "This is a 3-channel normal map image (or 4-channel where the 4th channel is ignored). This layer and the \"heightmap\" layer should not both be defined at the same time.",
+      "$ref": "#/definitions/file_name"
+    },
+    "heightmap": {
+      "title": "Heightmap",
+      "description": "1-channel layer image or a single value in this JSON file for a uniform heightmap. This layer and the \"normal\" layer should not both be defined at the same time.",
+      "examples": [255],
+      "anyOf": [
+        {
+          "$ref": "#/definitions/file_name"
+        },
+        {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        }
+      ]
+    },
+    "mer": {
+      "title": "Metalness Emissive Roughness",
+      "description": "This is a 3-channel image (or 4-channel where the 4th channel is ignored) or a 3-value array for a uniform MER. RGB images map Red to Metalness, Green to Emissive, and Blue to Roughness.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/file_name"
+        },
+        {
+          "$ref": "#/definitions/rgb"
+        }
+      ]
+    },
+    "mers": {
+      "title": "Metalness Emissive Roughness Subsurface",
+      "description": "This is a 4-channel image or a 4-value array for a uniform MERS. RGBA images map Red to Metalness, Green to Emissive, Blue to Roughness and Alpha to Subsurface.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/file_name"
+        },
+        {
+          "$ref": "#/definitions/rgba"
         }
       ]
     }

--- a/vscode-settings.json
+++ b/vscode-settings.json
@@ -560,16 +560,16 @@
     },
     {
       "fileMatch": [
-        "resource_packs/*/textures/*/*.{json,jsonc,json5}",
-        "*resource*pack*/textures/*/*.{json,jsonc,json5}",
-        "*Resource*Pack*/textures/*/*.{json,jsonc,json5}",
-        "*RP*/textures/*/*.{json,jsonc,json5}",
-        "*rp*/textures/*/*.{json,jsonc,json5}",
-        "resource_packs/*/textures/*/**/*.{json,jsonc,json5}",
-        "*resource*pack*/textures/*/**/*.{json,jsonc,json5}",
-        "*Resource*Pack*/textures/*/**/*.{json,jsonc,json5}",
-        "*RP*/textures/*/**/*.{json,jsonc,json5}",
-        "*rp*/textures/*/**/*.{json,jsonc,json5}"
+        "resource_packs/*/textures/*/!(*.texture_set).{json,jsonc,json5}",
+        "*resource*pack*/textures/*/!(*.texture_set).{json,jsonc,json5}",
+        "*Resource*Pack*/textures/*/!(*.texture_set).{json,jsonc,json5}",
+        "*RP*/textures/*/!(*.texture_set).{json,jsonc,json5}",
+        "*rp*/textures/*/!(*.texture_set).{json,jsonc,json5}",
+        "resource_packs/*/textures/*/**/!(*.texture_set).{json,jsonc,json5}",
+        "*resource*pack*/textures/*/**/!(*.texture_set).{json,jsonc,json5}",
+        "*Resource*Pack*/textures/*/**/!(*.texture_set).{json,jsonc,json5}",
+        "*RP*/textures/*/**/!(*.texture_set).{json,jsonc,json5}",
+        "*rp*/textures/*/**/!(*.texture_set).{json,jsonc,json5}"
       ],
       "url": "https://raw.githubusercontent.com/Blockception/Minecraft-bedrock-json-schemas/main/resource/textures/ui_texture_definition.json"
     },


### PR DESCRIPTION
- Require that `format_version` is set to one of the supported values: `1.16.100` or `1.21.30`.

  ![image](https://github.com/user-attachments/assets/feb33b92-7c0a-4540-982c-cb6ae4413261)

- Added support for the `metalness_emissive_roughness_subsurface` parameter.

  ![image](https://github.com/user-attachments/assets/c5b8c1c3-7c9d-4b88-80b9-6df6b0bfed56)

- Incompatible parameters can no longer be specified together (`heightmap` and `normal`, `metalness_emissive_roughness` and `metalness_emissive_roughness_subsurface`).

  ![image](https://github.com/user-attachments/assets/41085a82-d612-4b7d-b164-ab9a285743d1)
  ![image](https://github.com/user-attachments/assets/a42fc70d-ef57-472b-9739-be4eb3462b2d)

- Array color values are now validated correctly

  ![image](https://github.com/user-attachments/assets/37020564-1a08-4cb2-abde-dd6db0d60c7f)
