### PR TITLE
Fix BP entity snippet

### DIFF
--- a/source/behavior/entities/entities.json
+++ b/source/behavior/entities/entities.json
@@ -9,9 +9,9 @@
         "minecraft:entity": {
           "description": {
             "identifier": "$2:${3:${TM_FILENAME/[\\.].*//}}",
-            "is_spawnable": "^{4:true}",
-            "is_summonable": "^{5:true}",
-            "is_experimental": "^{6:false}"
+            "is_spawnable": "${4:true}",
+            "is_summonable": "${5:true}",
+            "is_experimental": "${6:false}"
           },
           "components": "^{$7}"
         }


### PR DESCRIPTION
Currently the default snippet leaves `{4:true}` instead of `true` value, that can be changed for `is_spawnable`. Same happens for 2 other boolean properties.

This small change should fix this issue.