### PR TITLE
Add uv_rotation to model_entity 1.21.0

### DIFF
--- a/source/resource/models/entity/1.21.0/model_entity.json
+++ b/source/resource/models/entity/1.21.0/model_entity.json
@@ -42,6 +42,15 @@
                     "type": "string",
                     "title": "Material Instance",
                     "description": "Specifies the UV's for the face that stretches."
+                },
+                "uv_rotation": {
+                    "title": "Uv Rotation",
+                    "description": "Specifies an optional rotation for the specified UV rect in 90-degree clockwise increments before applying it to a geometry cube face. If not specified, no rotation will be applied.",
+                    "enum": [
+                        90,
+                        180,
+                        270
+                    ]
                 }
             }
         },


### PR DESCRIPTION
Add `uv_rotation` to model_entity.json schema for 1.21.0.

Source: https://learn.microsoft.com/en-us/minecraft/creator/reference/content/schemasreference/schemas/minecraftschema_geometry_1.21.0?view=minecraft-bedrock-stable
