### PR TITLE
Add boolean to deals_damage

### DIFF
--- a/source/behavior/entities/format/components/damage_sensor.json
+++ b/source/behavior/entities/format/components/damage_sensor.json
@@ -51,7 +51,7 @@
         "deals_damage": {
           "title": "Deals Damage",
           "description": "Defines how received damage affects the entity:\n- 'yes', received damage is applied to the entity.\n- 'no', received damage is not applied to the entity.\n- 'no_but_side_effects_apply', received damage is not applied to the entity, but the side effects of the attack are. This means that the attacker's weapon loses durability, enchantment side effects are applied, and so on.",
-          "enum": [ "yes", "no", "no_but_side_effects_apply" ],
+          "enum": [ "yes", "no", "no_but_side_effects_apply", true, false ],
           "default": "yes"
         },
         "on_damage": {


### PR DESCRIPTION
`deals_damage` in `damage_sensor` entity component supports `true` and `false`.

Source: https://learn.microsoft.com/en-us/minecraft/creator/reference/content/entityreference/examples/entitycomponents/minecraftcomponent_damage_sensor?view=minecraft-bedrock-experimental#damage-sensor-properties
