### PR TITLE
fix: remove incorrect type definitions in features

### DIFF
--- a/source/behavior/features/features/minecraft.geode_feature.json
+++ b/source/behavior/features/features/minecraft.geode_feature.json
@@ -68,31 +68,26 @@
     },
     "filler": {
       "title": "Filler",
-      "type": "string",
       "description": "The block to fill the inside of the geode.",
       "$ref": "../../../general/block/reference.json"
     },
     "inner_layer": {
       "title": "Inner Layer",
-      "type": "string",
       "description": "The block that forms the inside layer of the geode shell.",
       "$ref": "../../../general/block/reference.json"
     },
     "alternate_inner_layer": {
       "title": "Alternate Inner Layer",
-      "type": "string",
       "description": "The block that has a chance of generating instead of inner_layer.",
       "$ref": "../../../general/block/reference.json"
     },
     "middle_layer": {
       "title": "Middle Layer",
-      "type": "string",
       "description": "The block that forms the middle layer of the geode shell.",
       "$ref": "../../../general/block/reference.json"
     },
     "outer_layer": {
       "title": "Outer Layer",
-      "type": "string",
       "description": "The block that forms the outer shell of the geode.",
       "$ref": "../../../general/block/reference.json"
     },

--- a/source/behavior/features/features/minecraft.growing_plant_feature.json
+++ b/source/behavior/features/features/minecraft.growing_plant_feature.json
@@ -43,7 +43,6 @@
           {
             "title": "Plant Body Block",
             "description": "Plant body block.",
-            "type": "string",
             "$ref": "../../../general/block/reference.json"
           },
           {

--- a/source/behavior/features/features/minecraft.multiface_feature.json
+++ b/source/behavior/features/features/minecraft.multiface_feature.json
@@ -11,7 +11,6 @@
     "places_block": {
       "title": "Places Block",
       "description": "Reference to the block to be placed.",
-      "type": "string",
       "$ref": "../../../general/block/reference.json"
     },
     "search_range": {

--- a/source/behavior/features/features/minecraft.nether_cave_carver_feature.json
+++ b/source/behavior/features/features/minecraft.nether_cave_carver_feature.json
@@ -11,7 +11,6 @@
     "fill_with": {
       "title": "Identifier",
       "description": "Reference to the block to fill the cave with.",
-      "type": "string",
       "$ref": "../../../general/block/reference.json"
     },
     "width_modifier": {

--- a/source/behavior/features/features/minecraft.single_block_feature.json
+++ b/source/behavior/features/features/minecraft.single_block_feature.json
@@ -3,13 +3,34 @@
   "description": "`minecraft:single_block_feature` places a single block in the world. The `may_place_on` and `may_replace` fields are allowlists which specify where the block can be placed. If these fields are omitted, the block can be placed anywhere. The block's internal survivability and placement rules can optionally be enforced with the `enforce_survivability_rules` and `enforce_placement_rules` fields. These rules are specified per-block and are typically designed to produce high quality gameplay or natural behavior. However, enabling this enforcement may make it harder to debug placement failures.\n Succeeds if: The block is successfully placed in the world.\n Fails if: The block fails to be placed.",
   "type": "object",
   "additionalProperties": false,
-  "required": [ "description", "places_block", "enforce_placement_rules", "enforce_survivability_rules" ],
+  "required": ["description", "places_block", "enforce_placement_rules", "enforce_survivability_rules"],
   "definitions": {
     "block_side": {
       "oneOf": [
-        { "title": "Block", "description": "Reference to the block it may attach to.", "type": "string", "$ref": "../../../general/block/reference.json" },
-        { "type": "array", "items": { "title": "Block", "description": "Reference to the block it may attach to.", "type": "string", "$ref": "../../../general/block/reference.json" } }
+        { "title": "Block", "description": "Reference to the block it may attach to.", "$ref": "../../../general/block/reference.json" },
+        {
+          "type": "array",
+          "items": { "title": "Block", "description": "Reference to the blocks it may attach to.", "$ref": "../../../general/block/reference.json" }
+        }
       ]
+    },
+    "weighted_block_reference": {
+      "title": "Weighted Block Reference",
+      "description": "Reference to the block to be placed.",
+      "type": "object",
+      "required": ["block"],
+      "properties": {
+        "block": {
+          "title": "Block",
+          "description": "Reference to the block to be placed.",
+          "$ref": "../../../general/block/reference.json"
+        },
+        "weight": {
+          "title": "Weight",
+          "description": "Random weight of this block. A higher number will increase the probability of this block to be picked during placement.",
+          "type": "number"
+        }
+      }
     }
   },
   "properties": {
@@ -21,7 +42,6 @@
         {
           "title": "Places Block",
           "description": "Reference to the block to be placed.",
-          "type": "string",
           "$ref": "../../../general/block/reference.json"
         },
         {
@@ -30,17 +50,7 @@
           "type": "array",
           "minItems": 1,
           "items": {
-            "title": "Block",
-            "description": "Reference to the block to be placed.",
-            "type": "array",
-            "items": [
-              { "title": "Block", "description": "Reference to the block to be placed.", "$ref": "../../../general/block/reference.json" },
-              {
-                "title": "Weight",
-                "description": "Random weight of this block. A higher number will increase the probability of this block to be picked during placement.",
-                "type": "number"
-              }
-            ]
+            "$ref": "#/definitions/weighted_block_reference"
           }
         }
       ]
@@ -112,7 +122,6 @@
       "items": {
         "title": "Block",
         "description": "A block that may be replaced during placement. Omit this field to allow any block to be replaced.",
-        "type": "string",
         "$ref": "../../../general/block/reference.json"
       }
     }

--- a/source/behavior/features/features/minecraft.structure_template_feature.json
+++ b/source/behavior/features/features/minecraft.structure_template_feature.json
@@ -12,7 +12,7 @@
       "title": "Structure Name",
       "description": "Reference to the structure to be placed.",
       "type": "string",
-      "pattern": "^\\w+:(\\w|\/)+"
+      "pattern": "^\\w+:(\\w|/)+"
     },
     "adjustment_radius": {
       "title": "Adjustment Radius",
@@ -60,7 +60,6 @@
               "type": "array",
               "items": {
                 "title": "Block",
-                "type": "string",
                 "$ref": "../../../general/block/reference.json"
               }
             },
@@ -70,7 +69,6 @@
               "type": "array",
               "items": {
                 "title": "Block",
-                "type": "string",
                 "$ref": "../../../general/block/reference.json"
               }
             }

--- a/source/behavior/features/features/minecraft.tree_feature.json
+++ b/source/behavior/features/features/minecraft.tree_feature.json
@@ -111,7 +111,6 @@
                 "decoration_block": {
                   "title": "Decoration Block",
                   "description": "The block used for decorating the trunk.",
-                  "type": "string",
                   "$ref": "../../../general/block/reference.json"
                 },
                 "num_steps": {
@@ -202,7 +201,7 @@
             "leaf_placement_attempts": {
               "title": "Leaf Placement Attempts",
               "description": "Max number of attempts to create leaf blocks.",
-              "type": "integer", 
+              "type": "integer",
               "minimum": 1
             },
             "leaf_blocks": {
@@ -210,16 +209,16 @@
               "description": "The blocks that form the canopy of the tree",
               "type": "array",
               "minItems": 1,
-              "items": [ 
-                  {
-                    "$ref": "#/definitions/leaf_block"
-                  }, 
-                  {
-                    "title": "Weight",
-                    "description": "Weight used in random selection. Value is relative to other weights in the collection.",
-                    "type": "number", 
-                    "minimum": 0
-                  }
+              "items": [
+                {
+                  "$ref": "#/definitions/leaf_block"
+                },
+                {
+                  "title": "Weight",
+                  "description": "Weight used in random selection. Value is relative to other weights in the collection.",
+                  "type": "number",
+                  "minimum": 0
+                }
               ]
             },
             "canopy_decoration": {
@@ -279,7 +278,7 @@
             "radius_step_modifier": {
               "title": "Radius Step Modifier",
               "description": "Modifier for the base radius of the canopy.",
-              "type": "number", 
+              "type": "number",
               "minimum": 0
             },
             "core_width": {
@@ -379,7 +378,6 @@
     "leaf_block": {
       "title": "Leaf Block",
       "description": "The block thata forms the canopy of the tree.",
-      "type": "string",
       "$ref": "../../../general/block/reference.json"
     },
     "trunk_width": {
@@ -391,13 +389,13 @@
     "height": {
       "title": "Height",
       "description": "Number of layers for the canopy.",
-      "type": "integer", 
+      "type": "integer",
       "minimum": 1
     },
     "radius": {
       "title": "Radius",
       "description": "The radius of the canopy.",
-      "type": "integer", 
+      "type": "integer",
       "minimum": 1
     },
     "decoration": {
@@ -414,7 +412,6 @@
         "decoration_block": {
           "title": "Decoration Block",
           "description": "The block used for decorating the trunk.",
-          "type": "string",
           "$ref": "../../../general/block/reference.json"
         },
         "num_steps": {
@@ -439,7 +436,6 @@
     "trunk_block": {
       "title": "Trunk Block",
       "description": "The block that forms the tree trunk.",
-      "type": "string",
       "$ref": "../../../general/block/reference.json"
     }
   },
@@ -552,7 +548,7 @@
         "trunk_lean": {
           "title": "Trunk Lean",
           "description": "Configuration object for diagonal branches.",
-          "type": "object", 
+          "type": "object",
           "additionalProperties": false,
           "properties": {
             "allow_diagonal_growth": {
@@ -614,7 +610,7 @@
     "cherry_trunk": {
       "title": "Cherry Trunk",
       "description": "Configutarion for the cherry trunk.",
-      "type": "object", 
+      "type": "object",
       "additionalProperties": false,
       "properties": {
         "trunk_block": {
@@ -653,25 +649,25 @@
             "tree_type_weights": {
               "title": "Tree Type Weights",
               "description": "Configuration object to pick a tree variant based on a weighted random number",
-              "type": "object", 
+              "type": "object",
               "additionalProperties": false,
               "properties": {
                 "one_branch": {
                   "title": "One Branch",
                   "description": "Tree variant with one branch.",
-                  "type": "integer", 
+                  "type": "integer",
                   "minimum": 0
                 },
                 "two_branches": {
                   "title": "Two Branches",
                   "description": "Tree variant with two branches.",
-                  "type": "integer", 
+                  "type": "integer",
                   "minimum": 0
                 },
                 "two_branches_and_trunk": {
                   "title": "Two Branches And Trunk",
                   "description": "Tree variant with three branch.",
-                  "type": "integer", 
+                  "type": "integer",
                   "minimum": 0
                 }
               }
@@ -824,7 +820,7 @@
     "mangrove_trunk": {
       "title": "Mangrove Trunk",
       "description": "Configutarion for the mangrove trunk.",
-      "type": "object", 
+      "type": "object",
       "additionalProperties": false,
       "properties": {
         "trunk_width": {
@@ -951,8 +947,8 @@
               "minimum": 0,
               "maximum": 1
             },
-            "branch_interval": { 
-              "title": "Branch Interval", 
+            "branch_interval": {
+              "title": "Branch Interval",
               "description": "Randomized distance between branches.",
               "$ref": "../../entities/format/types/range_number_type.json"
             },
@@ -1130,7 +1126,6 @@
             "decoration_block": {
               "title": "Decoration Block",
               "description": "The block used for decorating the trunk.",
-              "type": "string",
               "$ref": "../../../general/block/reference.json"
             },
             "num_steps": {
@@ -1221,7 +1216,7 @@
         "leaf_placement_attempts": {
           "title": "Leaf Placement Attempts",
           "description": "Max number of attempts to create leaf blocks.",
-          "type": "integer", 
+          "type": "integer",
           "minimum": 1
         },
         "leaf_blocks": {
@@ -1229,16 +1224,16 @@
           "description": "The blocks that form the canopy of the tree",
           "type": "array",
           "minItems": 1,
-          "items": [ 
-              {
-                "$ref": "#/definitions/leaf_block"
-              }, 
-              {
-                "title": "Weight",
-                "description": "Weight used in random selection. Value is relative to other weights in the collection.",
-                "type": "number", 
-                "minimum": 0
-              }
+          "items": [
+            {
+              "$ref": "#/definitions/leaf_block"
+            },
+            {
+              "title": "Weight",
+              "description": "Weight used in random selection. Value is relative to other weights in the collection.",
+              "type": "number",
+              "minimum": 0
+            }
           ]
         },
         "canopy_decoration": {
@@ -1298,7 +1293,7 @@
         "radius_step_modifier": {
           "title": "Radius Step Modifier",
           "description": "Modifier for the base radius of the canopy.",
-          "type": "number", 
+          "type": "number",
           "minimum": 0
         },
         "core_width": {
@@ -1416,16 +1411,16 @@
           "description": "The blocks that form the canopy of the tree",
           "type": "array",
           "minItems": 1,
-          "items": [ 
-              {
-                "$ref": "#/definitions/leaf_block"
-              }, 
-              {
-                "title": "Weight",
-                "description": "Weight used in random selection. Value is relative to other weights in the collection.",
-                "type": "number", 
-                "minimum": 0
-              }
+          "items": [
+            {
+              "$ref": "#/definitions/leaf_block"
+            },
+            {
+              "title": "Weight",
+              "description": "Weight used in random selection. Value is relative to other weights in the collection.",
+              "type": "number",
+              "minimum": 0
+            }
           ]
         }
       }
@@ -1433,31 +1428,30 @@
     "mangrove_roots": {
       "title": "Mangrove Roots",
       "description": "Configuration for mangrove roots",
-      "type": "object", 
+      "type": "object",
       "additionalProperties": false,
       "properties": {
         "max_root_width": {
           "title": "Max Root Width",
           "description": "Max width that the roots can occupy. The width increases up to the max width while moving downwards. When a max width is reached, roots will grow vertically",
-          "type": "integer", 
+          "type": "integer",
           "minimum": 1
         },
         "max_root_length": {
           "title": "Max Root Length",
           "description": "Max length that the roots can occupy.",
-          "type": "integer", 
+          "type": "integer",
           "minimum": 1
         },
         "root_block": {
           "title": "Root Block",
           "description": "Block used for roots.",
-          "type": "string",
           "$ref": "../../../general/block/reference.json"
         },
         "above_root": {
           "title": "Above Root",
           "description": "Configuration object for blocks decorating the top of the roots",
-          "type": "object", 
+          "type": "object",
           "additionalProperties": false,
           "properties": {
             "above_root_chance": {
@@ -1468,19 +1462,16 @@
             "above_root_block": {
               "title": "Above Root Block",
               "description": "The block placed on the top of the roots.",
-              "type": "string",
               "$ref": "../../../general/block/reference.json"
             },
             "muddy_root_block": {
               "title": "Muddy Root Block",
               "description": "The block used for muddy roots.",
-              "type": "string",
               "$ref": "../../../general/block/reference.json"
             },
             "mud_block": {
               "title": "Mud Block",
               "description": "The block used to determine if a muddy root should be placed.",
-              "type": "string",
               "$ref": "../../../general/block/reference.json"
             },
             "y_offset": {

--- a/source/behavior/features/features/minecraft.vegetation_patch_feature.json
+++ b/source/behavior/features/features/minecraft.vegetation_patch_feature.json
@@ -14,14 +14,12 @@
       "type": "array",
       "items": {
         "title": "Replace Block",
-        "type": "string",
         "$ref": "../../../general/block/reference.json"
       }
     },
     "ground_block": {
       "title": "Ground Block",
       "description": "Block used to create a base for the vegetation patch.",
-      "type": "string",
       "$ref": "../../../general/block/reference.json"
     },
     "vegetation_feature": {


### PR DESCRIPTION
This PR removes incorrect `type` definition from block references as well as fixes array + weighted schema in single_block_feature