### PR TITLE
feat: adding required properties to fog/transition_fog

### DIFF
--- a/source/resource/fog/fog.json
+++ b/source/resource/fog/fog.json
@@ -58,10 +58,12 @@
           "description": "Additional fog data which will slowly transition to the distance fog of current biome.",
           "type": "object",
           "default": false,
+          "required": ["init_fog","min_percent", "mid_seconds", "mid_percent", "max_seconds"],
           "properties": {
             "init_fog": {
               "title": "Initial Fog",
               "description": "Initial fog that will slowly transition into water distance fog of the biome when player goes into water.",
+              "required": ["fog_color", "fog_start", "fog_end", "render_distance_type"],
               "type": "object",
               "properties": {
                 "fog_color": {


### PR DESCRIPTION
Added required properties to `transition_fog` settings. Attempting to create a `transition_fog` without these required properties makes the fog fail to load.
