### PR TITLE
Add support for `minecraft:support`

### DIFF
--- a/source/behavior/blocks/format/components/support.json
+++ b/source/behavior/blocks/format/components/support.json
@@ -4,7 +4,7 @@
   "description": "Defines the support shape of the block. Currently only allows for blocks to have the same shape as a Vanilla fence and Vanilla stair. To work with custom stairs, requires the use of minecraft:vertical_half and minecraft:cardinal_direction or minecraft:facing_direction which can be set through the minecraft:placement_direction block trait. Custom blocks without this component will default to unit cube support.",
   "additionalProperties": false,
   "type": "object",
-  "required": [],
+  "required": ["shape"],
   "properties": {
     "shape": {
       "title": "Shape",


### PR DESCRIPTION
Source of truth: https://learn.microsoft.com/en-us/minecraft/creator/reference/content/blockreference/examples/blockcomponents/minecraftblock_support