### PR TITLE
Update `language` and `entry` property descriptions for `manifest.json.dependencies.modules` schema

### DIFF
--- a/source/general/manifest/manifest.2.json
+++ b/source/general/manifest/manifest.2.json
@@ -233,7 +233,7 @@
           "entry": {
             "type": "string",
             "title": "Entry",
-            "description": "The javascript entry point for tests, only works if types has been set to `javascript`."
+            "description": "The entry file for the pack's scripts. Requires `type` to be set to `script`."
           }
         }
       }

--- a/source/general/manifest/manifest.3.json
+++ b/source/general/manifest/manifest.3.json
@@ -233,7 +233,7 @@
           "entry": {
             "type": "string",
             "title": "Entry",
-            "description": "The javascript entry point for tests, only works if types has been set to `javascript`."
+            "description": "The entry file for the pack's scripts. Requires `type` to be set to `script`."
           }
         }
       }


### PR DESCRIPTION
Description for `language` is as per [Microsoft's documentation](https://learn.microsoft.com/en-us/minecraft/creator/reference/content/addonsreference/packmanifest?view=minecraft-bedrock-stable#modules).

There is no official documentation for `entry`, so I changed the description to something that seemed more accurate.

Resolves #436.

---

I would like to highlight whether or not it'd be better to leave out "The only supported value is `javascript`", as it's already enforced by the enum. I've left it 1:1, as per Microsoft's documentation for now.