### PR TITLE
Update destruction_particles.json

### DIFF
--- a/source/behavior/blocks/format/components/destruction_particles.json
+++ b/source/behavior/blocks/format/components/destruction_particles.json
@@ -1,10 +1,9 @@
 {
   "$id": "blockception.minecraft.behavior.blocks.minecraft.destruction_particles",
   "title": "Destruction Particles",
-  "description": "[Experimental] Sets the particles that will be used when block is destroyed. This component can be omitted.",
+  "description": "Sets the particles that will be used when block is destroyed. This component can be omitted.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["texture"],
   "properties": {
     "texture": {
       "title": "Texture",
@@ -20,9 +19,10 @@
     "particle_count": {
       "title": "Particle Count",
       "description": "Number of particles to spawn on destruction",
-      "type": "integer",
+      "type": "number",
       "default": 100,
-      "maximum": 255
+      "maximum": 255,
+      "minimum": 0
     }
   }
 }


### PR DESCRIPTION
- Removed `[Experimental]` tag, as it is stable now.
- Added `minimum` to  `particle_count`.
- Changed type of `particle_count` from `integer` to `number`, as decimals _are_ actually allowed.
- Removed `texture` from `required`, `particle_count` is allowed standalone.