### PR TITLE
Improved accuracy of `minecraft:geometry` regex.

### DIFF
--- a/source/behavior/blocks/format/components/geometry.json
+++ b/source/behavior/blocks/format/components/geometry.json
@@ -5,7 +5,7 @@
   "oneOf": [
     {
       "type": "string",
-      "pattern": "^(?:minecraft:geometry\.(full_block(_v1)?|cross)|(?!minecraft:)[a-z0-9].*[a-z0-9])$"
+      "pattern": "^(?:minecraft:geometry\\.(full_block(_v1)?|cross)|(?!minecraft:)[a-z0-9].*[a-z0-9])$"
     },
     {
       "type": "object",
@@ -16,7 +16,7 @@
           "title": "Identifier",
           "description": "The description identifier of the geometry file to use to render this block. This identifier must match an existing geometry identifier in any of the currently loaded resource packs.",
           "type": "string",
-          "pattern": "^(?:minecraft:geometry\.(full_block(_v1)?|cross)|(?!minecraft:)[a-z0-9].*[a-z0-9])$"
+          "pattern": "^(?:minecraft:geometry\\.(full_block(_v1)?|cross)|(?!minecraft:)[a-z0-9].*[a-z0-9])$"
         },
         "bone_visibility": {
           "title": "Bone Visibility",


### PR DESCRIPTION
This regex makes the `minecraft:geometry` regex better match the game, and allows it to properly validate the following vanilla geometries:
- `minecraft:geometry.cross`
- `minecraft:geometry.full_block`
- `minecraft:geometry.full_block_v1`[^1]

[^1]: This hasn't been added to stable yet, but it is in 26.0 previews, and the 26.0 preview cycle has ended as we are now in 26.10, so it will likely be added very soon.