### PR TITLE
fix: manifest version 3 needs to be a string semvar for min_engine_version

### DIFF
--- a/source/general/manifest/manifest.3.json
+++ b/source/general/manifest/manifest.3.json
@@ -166,8 +166,8 @@
         },
         "min_engine_version": {
           "title": "Minimum Engine Version",
-          "$ref": "../Version.json",
-          "description": "This is the minimum version of the game that this pack was written for. This is a required field for resource and behavior packs. This helps the game identify whether any backwards compatibility is needed for your pack. You should always use the highest version currently available when creating packs"
+          "$ref": "../semver.json",
+          "description": "This is the minimum version of the game that this pack was written for. This is a required field for resource and behavior packs. This helps the game identify whether any backwards compatibility is needed for your pack. You should always use the highest version currently available when creating packs. In version 3, currently in preview, you must use a string for version."
         },
         "name": {
           "title": "Name",

--- a/source/general/semversion.json
+++ b/source/general/semversion.json
@@ -1,0 +1,24 @@
+{
+  "$id": "semvar",
+  "title": "Semantic Versioning",
+  "description": "A semantic version",
+  "pattern": "^([1-9]+)\\.([0-9]+)\\.([0-9]+)$",
+  "type": "string",
+  "default": "1.26.0",
+  "examples": [
+    "1.26.0",
+    "1.21.50",
+    "1.20.80",
+    "1.20.40",
+    "1.19.0",
+    "1.12.0",
+    "1.10.0",
+    "1.8.0"
+  ],
+  "defaultSnippets": [
+    {
+      "label": "New Format version",
+      "body": "1.${1|8,10,12,17,18,19,20|}.${3|2|0|}"
+    }
+  ]
+}


### PR DESCRIPTION
fix: manifest version 3 needs to be a string semvar for min_engine_version

Fixes: https://github.com/Blockception/minecraft-bedrock-language-server/issues/224