### PR TITLE
Fix 'minecraft:tags' to use an array instead of an object

### DIFF
--- a/source/behavior/blocks/format/components/tags.json
+++ b/source/behavior/blocks/format/components/tags.json
@@ -1,39 +1,30 @@
 {
   "$id": "blockception.minecraft.behavior.blocks.minecraft.tags",
   "title": "Tags",
-  "description": "Attach arbitrary string tags to this block.",
-  "type": "object",
-  "additionalProperties": false,
-  "required": [ "tags" ],
-  "properties": {
-    "tags": {
-      "title": "Tags",
-      "description": "An array that can contain multiple block tags.",
-      "type": "array",
-      "uniqueItems": true,
-      "minItems": 1,
-      "items": {
-        "anyOf": [
-          {
-            "enum": [
-              "minecraft:diamond_tier_destructible",
-              "minecraft:iron_tier_destructible",
-              "minecraft:is_axe_item_destructible",
-              "minecraft:is_hoe_item_destructible",
-              "minecraft:is_mace_item_destructible",
-              "minecraft:is_pickaxe_item_destructible",
-              "minecraft:is_shears_item_destructible",
-              "minecraft:is_shovel_item_destructible",
-              "minecraft:is_sword_item_destructible",
-              "minecraft:netherite_tier_destructible",
-              "minecraft:stone_tier_destructible",
-              "minecraft:has_fence_connections",
-              "minecraft:cornerable_stairs"
-            ]
-          },
-          { "type": "string" }
+  "description": "Use this component to define tags, vanilla or custom. Valid tags are of the format \"namespace:tag_name\". The array of tags must be non-empty.",
+  "type": "array",
+  "uniqueItems": true,
+  "minItems": 1,
+  "items": {
+    "anyOf": [
+      {
+        "enum": [
+          "minecraft:diamond_tier_destructible",
+          "minecraft:iron_tier_destructible",
+          "minecraft:is_axe_item_destructible",
+          "minecraft:is_hoe_item_destructible",
+          "minecraft:is_mace_item_destructible",
+          "minecraft:is_pickaxe_item_destructible",
+          "minecraft:is_shears_item_destructible",
+          "minecraft:is_shovel_item_destructible",
+          "minecraft:is_sword_item_destructible",
+          "minecraft:netherite_tier_destructible",
+          "minecraft:stone_tier_destructible",
+          "minecraft:has_fence_connections",
+          "minecraft:cornerable_stairs"
         ]
-      }
-    }
+      },
+      { "type": "string" }
+    ]
   }
 }


### PR DESCRIPTION
Fixes #553

Also changes `description` to match official documentation.